### PR TITLE
340 jg lta fails

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 ## Changes in version 1.0.0.dev1 (unreleased)
 
 ### Improvements and new Features
+* Global temporal attributes are adjusted automatically when opening new datasets
+* Global temporal attributes are adjusted automatically when converting from data frames
+* Normalization and subsetting operation implementation logic is refactored out to util so that it can be re-used throughout Cate
 
 ### Issues Fixed/Resolved
 
@@ -8,6 +11,8 @@
   [#391](https://github.com/CCI-Tools/cate/issues/391)
 * Multiple concurrent attempts to load the ODP index now always return the same result
   [#386](https://github.com/CCI-Tools/cate/issues/386)
+* Use global temporal attributes to determine temporal resolution in aggregation operations
+  [#340](https://github.com/CCI-Tools/cate/issues/340)
   
 ## Changes in version 0.9.0.dev7
 

--- a/cate/core/cdm.py
+++ b/cate/core/cdm.py
@@ -109,10 +109,11 @@ Components
 """
 
 from collections import OrderedDict
-from typing import List, Optional, Sequence, Union
+from typing import List, Optional, Union
 import xarray as xr
 
 from ..util.misc import object_to_qualified_name, qualified_name_to_object
+from ..util.opimpl import get_lat_dim_name_impl, get_lon_dim_name_impl
 
 __author__ = "Norman Fomferra (Brockmann Consult GmbH)," \
              "Janis Gailis (S[&]T Norway)"
@@ -324,7 +325,7 @@ def get_lon_dim_name(ds: Union[xr.Dataset, xr.DataArray]) -> Optional[str]:
     :param ds: An xarray Dataset
     :return: the name or None
     """
-    return _get_dim_name(ds, ['lon', 'longitude', 'long'])
+    return get_lon_dim_name_impl(ds)
 
 
 def get_lat_dim_name(ds: Union[xr.Dataset, xr.DataArray]) -> Optional[str]:
@@ -333,11 +334,4 @@ def get_lat_dim_name(ds: Union[xr.Dataset, xr.DataArray]) -> Optional[str]:
     :param ds: An xarray Dataset
     :return: the name or None
     """
-    return _get_dim_name(ds, ['lat', 'latitude'])
-
-
-def _get_dim_name(ds: Union[xr.Dataset, xr.DataArray], possible_names: Sequence[str]) -> Optional[str]:
-    for name in possible_names:
-        if name in ds.dims:
-            return name
-    return None
+    return get_lat_dim_name_impl(ds)

--- a/cate/core/types.py
+++ b/cate/core/types.py
@@ -48,6 +48,7 @@ from shapely.geometry import Point, Polygon, box
 from shapely.geometry.base import BaseGeometry
 
 from ..util import safe_eval, to_list, to_datetime_range, to_datetime
+from cate.util.opimpl import adjust_temporal_attrs_impl
 
 __author__ = "Janis Gailis (S[&]T Norway), " \
              "Norman Fomferra (Brockmann Consult GmbH), " \
@@ -559,7 +560,7 @@ class DatasetLike(Like[xr.Dataset]):
         if isinstance(value, xr.Dataset):
             return value
         if isinstance(value, pd.DataFrame):
-            return xr.Dataset.from_dataframe(value)
+            return adjust_temporal_attrs_impl(xr.Dataset.from_dataframe(value))
         raise ValueError('Value must be an xr.Dataset or pd.DataFrame')
 
     @classmethod

--- a/cate/ops/__init__.py
+++ b/cate/ops/__init__.py
@@ -50,7 +50,7 @@ def cate_init():
 from .select import select_var
 from .coregistration import coregister
 from .correlation import pearson_correlation_scalar, pearson_correlation
-from .normalize import normalize
+from .normalize import normalize, adjust_temporal_attrs, adjust_spatial_attrs
 from .io import open_dataset, save_dataset, read_object, write_object, read_text, write_text, read_json, write_json, \
     read_csv, read_geo_data_frame, read_geo_data_collection, read_netcdf, write_netcdf3, write_netcdf4
 from .plot import plot_map, plot, plot_data_frame
@@ -75,6 +75,8 @@ __all__ = [
     'upsample_2d',
     # .normalize
     'normalize',
+    'adjust_temporal_attrs',
+    'adjust_spatial_attrs',
     # .select
     'select_var',
     # .coregistration

--- a/cate/ops/aggregate.py
+++ b/cate/ops/aggregate.py
@@ -78,8 +78,9 @@ def long_term_average(ds: DatasetLike.TYPE,
                              ' running temporal aggregation on this dataset'
                              ' beforehand may help.')
     except KeyError:
-        raise ValueError('Could not determine temporal resolution. Running the'
-                         ' normalize operation may help.')
+        raise ValueError('Could not determine temporal resolution. Running'
+                         ' the adjust_temporal_attrs operation beforehand may'
+                         ' help.')
 
     var = VarNamesLike.convert(var)
     # Shallow
@@ -165,7 +166,8 @@ def temporal_aggregation(ds: DatasetLike.TYPE,
             raise ValueError('Temporal aggregation operation expects a daily dataset')
     except KeyError:
         raise ValueError('Could not determine temporal resolution. Running'
-                         ' the normalize operation beforehand may help.')
+                         ' the adjust_temporal_attrs operation beforehand may'
+                         ' help.')
 
     with monitor.observing("resample dataset"):
         retset = ds.resample(freq='MS', dim='time', keep_attrs=True, how=method)

--- a/cate/ops/aggregate.py
+++ b/cate/ops/aggregate.py
@@ -72,10 +72,14 @@ def long_term_average(ds: DatasetLike.TYPE,
                          ' dataset may help'.format(ds.time.dtype))
 
     # Check if we have a monthly dataset
-    if ds.attrs['time_coverage_resolution'] != 'P1M':
-        raise ValueError('Long term average operation expects a monthly dataset'
-                         ' running temporal aggregation on this dataset'
-                         ' beforehand may help.')
+    try:
+        if ds.attrs['time_coverage_resolution'] != 'P1M':
+            raise ValueError('Long term average operation expects a monthly dataset'
+                             ' running temporal aggregation on this dataset'
+                             ' beforehand may help.')
+    except KeyError:
+        raise ValueError('Could not determine temporal resolution. Running the'
+                         ' normalize operation may help.')
 
     var = VarNamesLike.convert(var)
     # Shallow
@@ -156,8 +160,12 @@ def temporal_aggregation(ds: DatasetLike.TYPE,
                          ' dataset may help'.format(ds.time.dtype))
 
     # Check if we have a daily dataset
-    if ds.attrs['time_coverage_resolution'] != 'P1D':
-        raise ValueError('Temporal aggregation operation expects a daily dataset')
+    try:
+        if ds.attrs['time_coverage_resolution'] != 'P1D':
+            raise ValueError('Temporal aggregation operation expects a daily dataset')
+    except KeyError:
+        raise ValueError('Could not determine temporal resolution. Running'
+                         ' the normalize operation beforehand may help.')
 
     with monitor.observing("resample dataset"):
         retset = ds.resample(freq='MS', dim='time', keep_attrs=True, how=method)

--- a/cate/ops/io.py
+++ b/cate/ops/io.py
@@ -32,6 +32,7 @@ from cate.core.objectio import OBJECT_IO_REGISTRY, ObjectIO
 from cate.core.op import OP_REGISTRY, op_input, op
 from cate.core.types import VarNamesLike, TimeRangeLike, PolygonLike, DictLike, FileLike
 from cate.ops.normalize import normalize as normalize_op
+from cate.ops.normalize import adjust_temporal_attrs
 from cate.util import Monitor
 
 _ALL_FILE_FILTER = dict(name='All Files', extensions=['*'])
@@ -78,7 +79,7 @@ def open_dataset(ds_name: str,
                                    local_ds_id=local_ds_id,
                                    monitor=monitor)
     if ds and normalize:
-        return normalize_op(ds)
+        return adjust_temporal_attrs(normalize_op(ds))
 
     return ds
 
@@ -331,7 +332,7 @@ def read_netcdf(file: str,
                          decode_times=decode_times,
                          engine=engine)
     if ds and normalize:
-        return normalize_op(ds)
+        return adjust_temporal_attrs(normalize_op(ds))
     return ds
 
 

--- a/cate/ops/normalize.py
+++ b/cate/ops/normalize.py
@@ -30,13 +30,9 @@ Components
 """
 
 import xarray as xr
-import numpy as np
-
-from jdcal import jd2gcal
-from datetime import datetime
 
 from cate.core.op import op, op_return
-from cate.core.cdm import get_lon_dim_name, get_lat_dim_name
+from cate.util.opimpl import normalize_impl, adjust_temporal_attrs_impl, adjust_spatial_attrs_impl
 
 
 @op(tags=['utility'], version='1.0')
@@ -60,108 +56,7 @@ def normalize(ds: xr.Dataset) -> xr.Dataset:
     :param ds: The dataset to normalize.
     :return: The normalized dataset, or the original dataset, if it is already "normal".
     """
-
-    ds = _normalize_lat_lon(ds)
-    ds = _normalize_lat_lon_2d(ds)
-
-    # Handle Julian Day Time
-    try:
-        if ds.time.long_name.lower().strip() == 'time in julian days':
-            return _normalize_jd2datetime(ds)
-    except AttributeError:
-        pass
-
-    return ds
-
-
-def _normalize_lat_lon(ds: xr.Dataset) -> xr.Dataset:
-    """
-    Rename variables named 'longitude' or 'long' to 'lon', and 'latitude' to 'lon'.
-    :param ds: some xarray dataset
-    :return: a normalized xarray dataset, or the original one
-    """
-    lat_name = get_lat_dim_name(ds)
-    lon_name = get_lon_dim_name(ds)
-
-    name_dict = dict()
-    if lat_name and 'lat' not in ds:
-        name_dict[lat_name] = 'lat'
-
-    if lon_name and 'lon' not in ds:
-        name_dict[lon_name] = 'lon'
-
-    if name_dict:
-        ds = ds.rename(name_dict)
-
-    return ds
-
-
-def _normalize_lat_lon_2d(ds: xr.Dataset) -> xr.Dataset:
-    """
-    Detect 2D 'lat', 'lon' variables that span a equi-rectangular grid. Then:
-    Drop original 'lat', 'lon' variables
-    Rename original dimensions names of 'lat', 'lon' variables, usually ('y', 'x'), to ('lat', 'lon').
-    Insert new 1D 'lat', 'lon' coordinate variables with dimensions 'lat' and 'lon', respectively.
-    :param ds: some xarray dataset
-    :return: a normalized xarray dataset, or the original one
-    """
-    if not ('lat' in ds and 'lon' in ds):
-        return ds
-
-    lat_var = ds['lat']
-    lon_var = ds['lon']
-
-    lat_dims = lat_var.dims
-    lon_dims = lon_var.dims
-    if lat_dims != lon_dims:
-        return ds
-
-    spatial_dims = lon_dims
-    if len(spatial_dims) != 2:
-        return ds
-
-    x_dim_name = spatial_dims[-1]
-    y_dim_name = spatial_dims[-2]
-
-    lat_data_1 = lat_var[:, 0]
-    lat_data_2 = lat_var[:, -1]
-    lon_data_1 = lon_var[0, :]
-    lon_data_2 = lon_var[-1, :]
-
-    equal_lat = np.allclose(lat_data_1, lat_data_2, equal_nan=True)
-    equal_lon = np.allclose(lon_data_1, lon_data_2, equal_nan=True)
-    if not (equal_lat and equal_lon):
-        return ds
-
-    ds = ds.drop(['lon', 'lat'])
-
-    ds = ds.rename({
-        x_dim_name: 'lon',
-        y_dim_name: 'lat',
-    })
-
-    ds = ds.assign_coords(lon=np.array(lon_data_1), lat=np.array(lat_data_1))
-
-    return ds
-
-
-def _normalize_jd2datetime(ds: xr.Dataset) -> xr.Dataset:
-    """
-    Convert the time dimension of the given dataset from Julian date to
-    datetime.
-
-    :param ds: Dataset on which to run conversion
-    """
-    ds = ds.copy()
-    # Decode JD time
-    tuples = [jd2gcal(x, 0) for x in ds.time.values]
-    # Replace JD time with datetime
-    ds.time.values = [datetime(x[0], x[1], x[2]) for x in tuples]
-    # Adjust attributes
-    ds.time.attrs['long_name'] = 'time'
-    ds.time.attrs['calendar'] = 'standard'
-
-    return ds
+    return normalize_impl(ds)
 
 
 @op(tags=['utility'], version='1.0')
@@ -180,36 +75,7 @@ def adjust_spatial_attrs(ds: xr.Dataset) -> xr.Dataset:
     :param ds: Dataset to adjust
     :return: Adjusted dataset
     """
-    ds = ds.copy()
-
-    for dim in ('lon', 'lat'):
-        geoattrs = _get_spatial_props(ds, dim)
-
-        for key in geoattrs:
-            if geoattrs[key] is not None:
-                ds.attrs[key] = geoattrs[key]
-
-    lon_min = ds.attrs['geospatial_lon_min']
-    lat_min = ds.attrs['geospatial_lat_min']
-    lon_max = ds.attrs['geospatial_lon_max']
-    lat_max = ds.attrs['geospatial_lat_max']
-
-    ds.attrs['geospatial_bounds'] = 'POLYGON(({} {}, {} {}, {} {},\
- {} {}, {} {}))'.format(lon_min, lat_min, lon_min, lat_max, lon_max, lat_max,
-                        lon_max, lat_min, lon_min, lat_min)
-
-    # Determination of the following attributes from introspection in a general
-    # way is ambiguous, hence it is safer to drop them than to risk preserving
-    # out of date attributes.
-    drop = ['geospatial_bounds_crs', 'geospatial_bounds_vertical_crs',
-            'geospatial_vertical_min', 'geospatial_vertical_max',
-            'geospatial_vertical_positive', 'geospatial_vertical_units',
-            'geospatial_vertical_resolution']
-
-    for key in drop:
-        ds.attrs.pop(key, None)
-
-    return ds
+    return adjust_spatial_attrs_impl(ds)
 
 
 @op(tags=['utility'], version='1.0')
@@ -228,90 +94,4 @@ def adjust_temporal_attrs(ds: xr.Dataset) -> xr.Dataset:
     :param ds: Dataset to adjust
     :return: Adjusted dataset
     """
-    ds = ds.copy()
-
-    ds.attrs['time_coverage_start'] = str(ds.time.values[0])
-    ds.attrs['time_coverage_end'] = str(ds.time.values[-1])
-    ds.attrs['time_coverage_resolution'] = _get_temporal_res(ds.time.values)
-    ds.attrs['time_coverage_duration'] = _get_duration(ds.time.values)
-
-    return ds
-
-
-def _get_spatial_props(ds: xr.Dataset, dim: str) -> dict:
-    """
-    Get spatial boundaries, resolution and units of the given dimension of the given
-    dataset. If the 'bounds' are explicitly defined, these will be used for
-    boundary calculation, otherwise it will rest purely on information gathered
-    from 'dim' itself.
-
-    :param ds: Dataset
-    :param dim: Dimension name
-    :return: A dictionary {'attr_name': attr_value}
-    """
-    ret = dict()
-
-    try:
-        dim_res = abs(ds[dim].values[1] - ds[dim].values[0])
-        res_name = 'geospatial_{}_resolution'.format(dim)
-        ret[res_name] = dim_res
-    except KeyError:
-        raise ValueError('Dimension {} not found in the provided dataset.'.format(dim))
-
-    min_name = 'geospatial_{}_min'.format(dim)
-    max_name = 'geospatial_{}_max'.format(dim)
-    units_name = 'geospatial_{}_units'.format(dim)
-
-    try:
-        # According to CF Conventions the corresponding 'bounds' variable name
-        # should be in the attributes of the coordinate variable
-        bnds = ds[dim].attrs['bounds']
-        dim_min = min(ds[bnds].values[0][0], ds[bnds].values[-1][1])
-        dim_max = max(ds[bnds].values[0][0], ds[bnds].values[-1][1])
-    except KeyError:
-        dim_min = min(ds[dim].values[0], ds[dim].values[-1]) - dim_res * 0.5
-        dim_max = max(ds[dim].values[0], ds[dim].values[-1]) + dim_res * 0.5
-
-    ret[max_name] = dim_max
-    ret[min_name] = dim_min
-
-    try:
-        dim_units = ds[dim].attrs['units']
-    except KeyError:
-        dim_units = None
-
-    ret[units_name] = dim_units
-
-    return ret
-
-
-def _get_temporal_res(time: np.ndarray) -> str:
-    """
-    Determine temporal resolution of the given datetimes array.
-
-    See also: `ISO 8601 Durations <https://en.wikipedia.org/wiki/ISO_8601#Durations>`_
-
-    :param time: A numpy array containing np.datetime64 objects
-    :return: Temporal resolution formatted as an ISO 8601:2004 duration string
-    """
-    delta = time[1] - time[0]
-    days = delta.astype('timedelta64[D]') / np.timedelta64(1, 'D')
-
-    if (27 < days) and (days < 32):
-        return 'P1M'
-    else:
-        return 'P{}D'.format(int(days))
-
-
-def _get_duration(time: np.ndarray) -> str:
-    """
-    Determine the duration of the given datetimes array.
-
-    See also: `ISO 8601 Durations <https://en.wikipedia.org/wiki/ISO_8601#Durations>`_
-
-    :param time: A numpy array containing np.datetime64 objects
-    :return: Temporal resolution formatted as an ISO 8601:2004 duration string
-    """
-    delta = time[-1] - time[0]
-    days = delta.astype('timedelta64[D]') / np.timedelta64(1, 'D')
-    return 'P{}D'.format(int(days))
+    return adjust_temporal_attrs_impl(ds)

--- a/cate/ops/normalize.py
+++ b/cate/ops/normalize.py
@@ -71,7 +71,7 @@ def normalize(ds: xr.Dataset) -> xr.Dataset:
     except AttributeError:
         pass
 
-    return adjust_temporal_attrs(ds)
+    return ds
 
 
 def _normalize_lat_lon(ds: xr.Dataset) -> xr.Dataset:
@@ -164,7 +164,7 @@ def _normalize_jd2datetime(ds: xr.Dataset) -> xr.Dataset:
     return ds
 
 
-@op(tags=['utility', 'internal'], version='1.0')
+@op(tags=['utility'], version='1.0')
 def adjust_spatial_attrs(ds: xr.Dataset) -> xr.Dataset:
     """
     Adjust the global spatial attributes of the dataset by doing some
@@ -212,7 +212,7 @@ def adjust_spatial_attrs(ds: xr.Dataset) -> xr.Dataset:
     return ds
 
 
-@op(tags=['utility', 'internal'], version='1.0')
+@op(tags=['utility'], version='1.0')
 def adjust_temporal_attrs(ds: xr.Dataset) -> xr.Dataset:
     """
     Adjust the global temporal attributes of the dataset by doing some

--- a/cate/ops/normalize.py
+++ b/cate/ops/normalize.py
@@ -71,7 +71,7 @@ def normalize(ds: xr.Dataset) -> xr.Dataset:
     except AttributeError:
         pass
 
-    return ds
+    return adjust_temporal_attrs(ds)
 
 
 def _normalize_lat_lon(ds: xr.Dataset) -> xr.Dataset:

--- a/cate/ops/subset.py
+++ b/cate/ops/subset.py
@@ -30,13 +30,13 @@ Components
 """
 
 import xarray as xr
-import numpy as np
-from shapely.geometry import Point, box, LineString
-from shapely.wkt import loads, dumps
 
 from cate.core.op import op, op_input, op_return
 from cate.core.types import PolygonLike, TimeRangeLike, DatasetLike
 from cate.ops.normalize import adjust_spatial_attrs, adjust_temporal_attrs
+
+from cate.util.opimpl import subset_spatial_impl, subset_temporal_impl
+from cate.util.opimpl import subset_temporal_index_impl
 
 
 @op(tags=['geometric', 'spatial', 'subset'], version='1.0')
@@ -54,125 +54,8 @@ def subset_spatial(ds: xr.Dataset,
     not the polygon itself be masked with NaN.
     :return: Subset dataset
     """
-    # Get the bounding box
     region = PolygonLike.convert(region)
-    lon_min, lat_min, lon_max, lat_max = region.bounds
-
-    # Validate the bounding box
-    if (not (-90 <= lat_min <= 90)) or \
-            (not (-90 <= lat_max <= 90)) or \
-            (not (-180 <= lon_min <= 180)) or \
-            (not (-180 <= lon_max <= 180)):
-        raise ValueError('Provided polygon extends outside of geospatial'
-                         ' bounds: latitude [-90;90], longitude [-180;180]')
-
-    simple_polygon = False
-    if region.equals(box(lon_min, lat_min, lon_max, lat_max)):
-        # Don't do the computationally intensive masking if the provided
-        # region is a simple box-polygon, for which there will be nothing to
-        # mask.
-        simple_polygon = True
-
-    crosses_antimeridian = _crosses_antimeridian(region)
-
-    if crosses_antimeridian and not simple_polygon:
-        # Unlikely but plausible
-        raise NotImplementedError('Spatial subset over the International Date'
-                                  ' Line is currently implemented for simple,'
-                                  ' rectangular polygons only.')
-
-    if crosses_antimeridian:
-        # Shapely messes up longitudes if the polygon crosses the antimeridian
-        lon_min, lon_max = lon_max, lon_min
-
-        # Can't perform a simple selection with slice, hence we have to
-        # construct an appropriate longitude indexer for selection
-        lon_left_of_idl = slice(lon_min, 180)
-        lon_right_of_idl = slice(-180, lon_max)
-        lon_index = xr.concat((ds.lon.sel(lon=lon_right_of_idl),
-                               ds.lon.sel(lon=lon_left_of_idl)), dim='lon')
-        indexers = {'lon': lon_index, 'lat': slice(lat_min, lat_max)}
-        retset = ds.sel(**indexers)
-
-        if mask:
-            # Preserve the original longitude dimension, masking elements that
-            # do not belong to the polygon with NaN.
-            return adjust_spatial_attrs(retset.reindex_like(ds.lon))
-        else:
-            # Return the dataset with no NaNs and with a disjoint longitude
-            # dimension
-            return adjust_spatial_attrs(retset)
-
-    if not mask or simple_polygon:
-        # The polygon doesn't cross the IDL, it is a simple box -> Use a simple slice
-        lat_slice = slice(lat_min, lat_max)
-        lon_slice = slice(lon_min, lon_max)
-        indexers = {'lat': lat_slice, 'lon': lon_slice}
-        return adjust_spatial_attrs(ds.sel(**indexers))
-
-    # Create the mask array. The result of this is a lon/lat DataArray where
-    # all values falling in the region or on its boundary are denoted with True
-    # and all the rest with False
-    lonm, latm = np.meshgrid(ds.lon.values, ds.lat.values)
-    mask = np.array([Point(lon, lat).intersects(region) for lon, lat in
-                     zip(lonm.ravel(), latm.ravel())], dtype=bool)
-    mask = xr.DataArray(mask.reshape(lonm.shape),
-                        coords={'lon': ds.lon, 'lat': ds.lat},
-                        dims=['lat', 'lon'])
-
-    # Mask values outside the polygon with NaN, crop the dataset
-    return adjust_spatial_attrs(ds.where(mask, drop=True))
-
-
-def _crosses_antimeridian(region: PolygonLike.TYPE) -> bool:
-    """
-    Determine if the given region crosses the Antimeridian line, by converting
-    the given Polygon from -180;180 to 0;360 and checking if the antimeridian
-    line crosses it.
-
-    This only works with Polygons without holes
-
-    :param region: PolygonLike to test
-    """
-    region = PolygonLike.convert(region)
-
-    # Retrieving the points of the Polygon are a bit troublesome, parsing WKT
-    # is more straightforward and probably faster
-    new_wkt = 'POLYGON (('
-
-    # [10:-2] gets rid of POLYGON (( and ))
-    for point in dumps(region)[10:-2].split(','):
-        point = point.strip()
-        lon, lat = point.split(' ')
-        lon = float(lon)
-        if -180 <= lon < 0:
-            lon += 360
-        new_wkt += '{} {}, '.format(lon, lat)
-    new_wkt = new_wkt[:-2] + '))'
-
-    converted = loads(new_wkt)
-
-    # There's a problem at this point. Any polygon crossed by the zeroth
-    # meridian can in principle convert to an inverted polygon that is crossed
-    # by the antimeridian.
-
-    if not converted.is_valid:
-        # The polygon 'became' invalid upon conversion => probably the original
-        # polygon is what we want
-        return False
-
-    test_line = LineString([(180, -90), (180, 90)])
-    if test_line.crosses(converted):
-        # The converted polygon seems to be valid and crossed by the
-        # antimeridian. At this point there's no 'perfect' way how to tell if
-        # we wanted the converted polygon or the original one.
-
-        # A simple heuristic is to check for size. The smaller one is quite
-        # likely the desired one
-        if converted.area < region.area:
-            return True
-        else:
-            return False
+    return adjust_spatial_attrs(subset_spatial_impl(ds, region, mask))
 
 
 @op(tags=['subset', 'temporal', 'filter'], version='1.0')
@@ -190,16 +73,7 @@ def subset_temporal(ds: DatasetLike.TYPE,
     """
     ds = DatasetLike.convert(ds)
     time_range = TimeRangeLike.convert(time_range)
-    # If it can be selected, go ahead
-    try:
-        time_slice = slice(time_range[0], time_range[1])
-        indexers = {'time': time_slice}
-        return adjust_temporal_attrs(ds.sel(**indexers))
-    except TypeError:
-        raise ValueError('Time subset operation expects a dataset with the'
-                         ' time coordinate of type datetime64[ns], but received'
-                         ' {}. Running the normalize operation on this'
-                         ' dataset may help'.format(ds.time.dtype))
+    return adjust_temporal_attrs(subset_temporal_impl(ds, time_range))
 
 
 @op(tags=['subset', 'temporal', 'filter', 'utility'], version='1.0')
@@ -217,8 +91,4 @@ def subset_temporal_index(ds: DatasetLike.TYPE,
     :return: Subset dataset
     """
     ds = DatasetLike.convert(ds)
-    # we're creating a slice that includes both ends
-    # to have the same functionality as subset_temporal
-    time_slice = slice(time_ind_min, time_ind_max + 1)
-    indexers = {'time': time_slice}
-    return ds.isel(**indexers)
+    return subset_temporal_index_impl(ds, time_ind_min, time_ind_max)

--- a/cate/util/__init__.py
+++ b/cate/util/__init__.py
@@ -49,3 +49,4 @@ from .undefined import UNDEFINED
 from .safe import safe_eval, get_safe_globals
 from .process import run_subprocess, ProcessOutputMonitor
 from .tmpfile import new_temp_file, del_temp_file, del_temp_files
+from .opimpl import normalize_impl, adjust_temporal_attrs_impl, adjust_spatial_attrs_impl

--- a/cate/util/opimpl.py
+++ b/cate/util/opimpl.py
@@ -1,0 +1,328 @@
+# The MIT License (MIT)
+# Copyright (c) 2016, 2017 by the ESA CCI Toolbox development team and contributors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do
+# so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+__author__ = "Janis Gailis (S[&]T Norway)"
+
+import xarray as xr
+import numpy as np
+from typing import Optional, Sequence, Union
+
+from jdcal import jd2gcal
+from datetime import datetime
+
+
+def normalize_impl(ds: xr.Dataset) -> xr.Dataset:
+    """
+    Normalize the geo- and time-coding upon opening the given dataset w.r.t.
+    to a common (CF-compatible) convention used within Cate. This will maximize the compatibility of
+    a dataset for usage with Cate's operations.
+
+    That is,
+    * variables named "latitude" will be renamed to "lat";
+    * variables named "longitude" or "long" will be renamed to "lon";
+
+    Then, for equi-rectangular grids,
+    * Remove 2D "lat" and "lon" variables;
+    * Two new 1D coordinate variables "lat" and "lon" will be generated from original 2D forms.
+
+    Finally, it will be ensured that a "time" coordinate variable will be of type *datetime*.
+
+    :param ds: The dataset to normalize.
+    :return: The normalized dataset, or the original dataset, if it is already "normal".
+    """
+
+    ds = _normalize_lat_lon(ds)
+    ds = _normalize_lat_lon_2d(ds)
+
+    # Handle Julian Day Time
+    try:
+        if ds.time.long_name.lower().strip() == 'time in julian days':
+            return _normalize_jd2datetime(ds)
+    except AttributeError:
+        pass
+
+    return ds
+
+
+def _normalize_lat_lon(ds: xr.Dataset) -> xr.Dataset:
+    """
+    Rename variables named 'longitude' or 'long' to 'lon', and 'latitude' to 'lon'.
+    :param ds: some xarray dataset
+    :return: a normalized xarray dataset, or the original one
+    """
+    lat_name = get_lat_dim_name_impl(ds)
+    lon_name = get_lon_dim_name_impl(ds)
+
+    name_dict = dict()
+    if lat_name and 'lat' not in ds:
+        name_dict[lat_name] = 'lat'
+
+    if lon_name and 'lon' not in ds:
+        name_dict[lon_name] = 'lon'
+
+    if name_dict:
+        ds = ds.rename(name_dict)
+
+    return ds
+
+
+def _normalize_lat_lon_2d(ds: xr.Dataset) -> xr.Dataset:
+    """
+    Detect 2D 'lat', 'lon' variables that span a equi-rectangular grid. Then:
+    Drop original 'lat', 'lon' variables
+    Rename original dimensions names of 'lat', 'lon' variables, usually ('y', 'x'), to ('lat', 'lon').
+    Insert new 1D 'lat', 'lon' coordinate variables with dimensions 'lat' and 'lon', respectively.
+    :param ds: some xarray dataset
+    :return: a normalized xarray dataset, or the original one
+    """
+    if not ('lat' in ds and 'lon' in ds):
+        return ds
+
+    lat_var = ds['lat']
+    lon_var = ds['lon']
+
+    lat_dims = lat_var.dims
+    lon_dims = lon_var.dims
+    if lat_dims != lon_dims:
+        return ds
+
+    spatial_dims = lon_dims
+    if len(spatial_dims) != 2:
+        return ds
+
+    x_dim_name = spatial_dims[-1]
+    y_dim_name = spatial_dims[-2]
+
+    lat_data_1 = lat_var[:, 0]
+    lat_data_2 = lat_var[:, -1]
+    lon_data_1 = lon_var[0, :]
+    lon_data_2 = lon_var[-1, :]
+
+    equal_lat = np.allclose(lat_data_1, lat_data_2, equal_nan=True)
+    equal_lon = np.allclose(lon_data_1, lon_data_2, equal_nan=True)
+    if not (equal_lat and equal_lon):
+        return ds
+
+    ds = ds.drop(['lon', 'lat'])
+
+    ds = ds.rename({
+        x_dim_name: 'lon',
+        y_dim_name: 'lat',
+    })
+
+    ds = ds.assign_coords(lon=np.array(lon_data_1), lat=np.array(lat_data_1))
+
+    return ds
+
+
+def _normalize_jd2datetime(ds: xr.Dataset) -> xr.Dataset:
+    """
+    Convert the time dimension of the given dataset from Julian date to
+    datetime.
+
+    :param ds: Dataset on which to run conversion
+    """
+    ds = ds.copy()
+    # Decode JD time
+    tuples = [jd2gcal(x, 0) for x in ds.time.values]
+    # Replace JD time with datetime
+    ds.time.values = [datetime(x[0], x[1], x[2]) for x in tuples]
+    # Adjust attributes
+    ds.time.attrs['long_name'] = 'time'
+    ds.time.attrs['calendar'] = 'standard'
+
+    return ds
+
+
+def adjust_spatial_attrs_impl(ds: xr.Dataset) -> xr.Dataset:
+    """
+    Adjust the global spatial attributes of the dataset by doing some
+    introspection of the dataset and adjusting the appropriate attributes
+    accordingly.
+
+    In case the determined attributes do not exist in the dataset, these will
+    be added.
+
+    For more information on suggested global attributes see
+    `Attribute Convention for Data Discovery <http://wiki.esipfed.org/index.php/Attribute_Convention_for_Data_Discovery>`_
+
+    :param ds: Dataset to adjust
+    :return: Adjusted dataset
+    """
+    ds = ds.copy()
+
+    for dim in ('lon', 'lat'):
+        geoattrs = _get_spatial_props(ds, dim)
+
+        for key in geoattrs:
+            if geoattrs[key] is not None:
+                ds.attrs[key] = geoattrs[key]
+
+    lon_min = ds.attrs['geospatial_lon_min']
+    lat_min = ds.attrs['geospatial_lat_min']
+    lon_max = ds.attrs['geospatial_lon_max']
+    lat_max = ds.attrs['geospatial_lat_max']
+
+    ds.attrs['geospatial_bounds'] = 'POLYGON(({} {}, {} {}, {} {},\
+ {} {}, {} {}))'.format(lon_min, lat_min, lon_min, lat_max, lon_max, lat_max,
+                        lon_max, lat_min, lon_min, lat_min)
+
+    # Determination of the following attributes from introspection in a general
+    # way is ambiguous, hence it is safer to drop them than to risk preserving
+    # out of date attributes.
+    drop = ['geospatial_bounds_crs', 'geospatial_bounds_vertical_crs',
+            'geospatial_vertical_min', 'geospatial_vertical_max',
+            'geospatial_vertical_positive', 'geospatial_vertical_units',
+            'geospatial_vertical_resolution']
+
+    for key in drop:
+        ds.attrs.pop(key, None)
+
+    return ds
+
+
+def adjust_temporal_attrs_impl(ds: xr.Dataset) -> xr.Dataset:
+    """
+    Adjust the global temporal attributes of the dataset by doing some
+    introspection of the dataset and adjusting the appropriate attributes
+    accordingly.
+
+    In case the determined attributes do not exist in the dataset, these will
+    be added.
+
+    For more information on suggested global attributes see
+    `Attribute Convention for Data Discovery <http://wiki.esipfed.org/index.php/Attribute_Convention_for_Data_Discovery>`_
+
+    :param ds: Dataset to adjust
+    :return: Adjusted dataset
+    """
+    ds = ds.copy()
+
+    ds.attrs['time_coverage_start'] = str(ds.time.values[0])
+    ds.attrs['time_coverage_end'] = str(ds.time.values[-1])
+    ds.attrs['time_coverage_resolution'] = _get_temporal_res(ds.time.values)
+    ds.attrs['time_coverage_duration'] = _get_duration(ds.time.values)
+
+    return ds
+
+
+def _get_spatial_props(ds: xr.Dataset, dim: str) -> dict:
+    """
+    Get spatial boundaries, resolution and units of the given dimension of the given
+    dataset. If the 'bounds' are explicitly defined, these will be used for
+    boundary calculation, otherwise it will rest purely on information gathered
+    from 'dim' itself.
+
+    :param ds: Dataset
+    :param dim: Dimension name
+    :return: A dictionary {'attr_name': attr_value}
+    """
+    ret = dict()
+
+    try:
+        dim_res = abs(ds[dim].values[1] - ds[dim].values[0])
+        res_name = 'geospatial_{}_resolution'.format(dim)
+        ret[res_name] = dim_res
+    except KeyError:
+        raise ValueError('Dimension {} not found in the provided dataset.'.format(dim))
+
+    min_name = 'geospatial_{}_min'.format(dim)
+    max_name = 'geospatial_{}_max'.format(dim)
+    units_name = 'geospatial_{}_units'.format(dim)
+
+    try:
+        # According to CF Conventions the corresponding 'bounds' variable name
+        # should be in the attributes of the coordinate variable
+        bnds = ds[dim].attrs['bounds']
+        dim_min = min(ds[bnds].values[0][0], ds[bnds].values[-1][1])
+        dim_max = max(ds[bnds].values[0][0], ds[bnds].values[-1][1])
+    except KeyError:
+        dim_min = min(ds[dim].values[0], ds[dim].values[-1]) - dim_res * 0.5
+        dim_max = max(ds[dim].values[0], ds[dim].values[-1]) + dim_res * 0.5
+
+    ret[max_name] = dim_max
+    ret[min_name] = dim_min
+
+    try:
+        dim_units = ds[dim].attrs['units']
+    except KeyError:
+        dim_units = None
+
+    ret[units_name] = dim_units
+
+    return ret
+
+
+def _get_temporal_res(time: np.ndarray) -> str:
+    """
+    Determine temporal resolution of the given datetimes array.
+
+    See also: `ISO 8601 Durations <https://en.wikipedia.org/wiki/ISO_8601#Durations>`_
+
+    :param time: A numpy array containing np.datetime64 objects
+    :return: Temporal resolution formatted as an ISO 8601:2004 duration string
+    """
+    delta = time[1] - time[0]
+    days = delta.astype('timedelta64[D]') / np.timedelta64(1, 'D')
+
+    if (27 < days) and (days < 32):
+        return 'P1M'
+    else:
+        return 'P{}D'.format(int(days))
+
+
+def _get_duration(time: np.ndarray) -> str:
+    """
+    Determine the duration of the given datetimes array.
+
+    See also: `ISO 8601 Durations <https://en.wikipedia.org/wiki/ISO_8601#Durations>`_
+
+    :param time: A numpy array containing np.datetime64 objects
+    :return: Temporal resolution formatted as an ISO 8601:2004 duration string
+    """
+    delta = time[-1] - time[0]
+    days = delta.astype('timedelta64[D]') / np.timedelta64(1, 'D')
+    return 'P{}D'.format(int(days))
+
+
+def get_lon_dim_name_impl(ds: Union[xr.Dataset, xr.DataArray]) -> Optional[str]:
+    """
+    Get the name of the longitude dimension.
+    :param ds: An xarray Dataset
+    :return: the name or None
+    """
+    return _get_dim_name(ds, ['lon', 'longitude', 'long'])
+
+
+def get_lat_dim_name_impl(ds: Union[xr.Dataset, xr.DataArray]) -> Optional[str]:
+    """
+    Get the name of the latitude dimension.
+    :param ds: An xarray Dataset
+    :return: the name or None
+    """
+    return _get_dim_name(ds, ['lat', 'latitude'])
+
+
+def _get_dim_name(ds: Union[xr.Dataset, xr.DataArray], possible_names: Sequence[str]) -> Optional[str]:
+    for name in possible_names:
+        if name in ds.dims:
+            return name
+    return None

--- a/cate/util/opimpl.py
+++ b/cate/util/opimpl.py
@@ -21,9 +21,12 @@
 
 __author__ = "Janis Gailis (S[&]T Norway)"
 
+from typing import Optional, Sequence, Union, Tuple
+
 import xarray as xr
 import numpy as np
-from typing import Optional, Sequence, Union
+from shapely.geometry import Point, box, LineString, Polygon
+from shapely.wkt import loads, dumps
 
 from jdcal import jd2gcal
 from datetime import datetime
@@ -326,3 +329,172 @@ def _get_dim_name(ds: Union[xr.Dataset, xr.DataArray], possible_names: Sequence[
         if name in ds.dims:
             return name
     return None
+
+
+def subset_spatial_impl(ds: xr.Dataset,
+                        region: Polygon,
+                        mask: bool = True) -> xr.Dataset:
+    """
+    Do a spatial subset of the dataset
+
+    :param ds: Dataset to subset
+    :param region: Spatial region to subset
+    :param mask: Should values falling in the bounding box of the polygon but
+    not the polygon itself be masked with NaN.
+    :return: Subset dataset
+    """
+    # Get the bounding box
+    lon_min, lat_min, lon_max, lat_max = region.bounds
+
+    # Validate the bounding box
+    if (not (-90 <= lat_min <= 90)) or \
+            (not (-90 <= lat_max <= 90)) or \
+            (not (-180 <= lon_min <= 180)) or \
+            (not (-180 <= lon_max <= 180)):
+        raise ValueError('Provided polygon extends outside of geospatial'
+                         ' bounds: latitude [-90;90], longitude [-180;180]')
+
+    simple_polygon = False
+    if region.equals(box(lon_min, lat_min, lon_max, lat_max)):
+        # Don't do the computationally intensive masking if the provided
+        # region is a simple box-polygon, for which there will be nothing to
+        # mask.
+        simple_polygon = True
+
+    crosses_antimeridian = _crosses_antimeridian(region)
+
+    if crosses_antimeridian and not simple_polygon:
+        # Unlikely but plausible
+        raise NotImplementedError('Spatial subset over the International Date'
+                                  ' Line is currently implemented for simple,'
+                                  ' rectangular polygons only.')
+
+    if crosses_antimeridian:
+        # Shapely messes up longitudes if the polygon crosses the antimeridian
+        lon_min, lon_max = lon_max, lon_min
+
+        # Can't perform a simple selection with slice, hence we have to
+        # construct an appropriate longitude indexer for selection
+        lon_left_of_idl = slice(lon_min, 180)
+        lon_right_of_idl = slice(-180, lon_max)
+        lon_index = xr.concat((ds.lon.sel(lon=lon_right_of_idl),
+                               ds.lon.sel(lon=lon_left_of_idl)), dim='lon')
+        indexers = {'lon': lon_index, 'lat': slice(lat_min, lat_max)}
+        retset = ds.sel(**indexers)
+
+        if mask:
+            # Preserve the original longitude dimension, masking elements that
+            # do not belong to the polygon with NaN.
+            return retset.reindex_like(ds.lon)
+        else:
+            # Return the dataset with no NaNs and with a disjoint longitude
+            # dimension
+            return retset
+
+    if not mask or simple_polygon:
+        # The polygon doesn't cross the IDL, it is a simple box -> Use a simple slice
+        lat_slice = slice(lat_min, lat_max)
+        lon_slice = slice(lon_min, lon_max)
+        indexers = {'lat': lat_slice, 'lon': lon_slice}
+        return ds.sel(**indexers)
+
+    # Create the mask array. The result of this is a lon/lat DataArray where
+    # all values falling in the region or on its boundary are denoted with True
+    # and all the rest with False
+    lonm, latm = np.meshgrid(ds.lon.values, ds.lat.values)
+    mask = np.array([Point(lon, lat).intersects(region) for lon, lat in
+                     zip(lonm.ravel(), latm.ravel())], dtype=bool)
+    mask = xr.DataArray(mask.reshape(lonm.shape),
+                        coords={'lon': ds.lon, 'lat': ds.lat},
+                        dims=['lat', 'lon'])
+
+    # Mask values outside the polygon with NaN, crop the dataset
+    return ds.where(mask, drop=True)
+
+
+def _crosses_antimeridian(region: Polygon) -> bool:
+    """
+    Determine if the given region crosses the Antimeridian line, by converting
+    the given Polygon from -180;180 to 0;360 and checking if the antimeridian
+    line crosses it.
+
+    This only works with Polygons without holes
+
+    :param region: PolygonLike to test
+    """
+    # Retrieving the points of the Polygon are a bit troublesome, parsing WKT
+    # is more straightforward and probably faster
+    new_wkt = 'POLYGON (('
+
+    # [10:-2] gets rid of POLYGON (( and ))
+    for point in dumps(region)[10:-2].split(','):
+        point = point.strip()
+        lon, lat = point.split(' ')
+        lon = float(lon)
+        if -180 <= lon < 0:
+            lon += 360
+        new_wkt += '{} {}, '.format(lon, lat)
+    new_wkt = new_wkt[:-2] + '))'
+
+    converted = loads(new_wkt)
+
+    # There's a problem at this point. Any polygon crossed by the zeroth
+    # meridian can in principle convert to an inverted polygon that is crossed
+    # by the antimeridian.
+
+    if not converted.is_valid:
+        # The polygon 'became' invalid upon conversion => probably the original
+        # polygon is what we want
+        return False
+
+    test_line = LineString([(180, -90), (180, 90)])
+    if test_line.crosses(converted):
+        # The converted polygon seems to be valid and crossed by the
+        # antimeridian. At this point there's no 'perfect' way how to tell if
+        # we wanted the converted polygon or the original one.
+
+        # A simple heuristic is to check for size. The smaller one is quite
+        # likely the desired one
+        if converted.area < region.area:
+            return True
+        else:
+            return False
+
+
+def subset_temporal_impl(ds: xr.Dataset,
+                         time_range: Tuple[datetime, datetime]) -> xr.Dataset:
+    """
+    Do a temporal subset of the dataset.
+
+    :param ds: Dataset or dataframe to subset
+    :param time_range: Time range to select
+    :return: Subset dataset
+    """
+    # If it can be selected, go ahead
+    try:
+        time_slice = slice(time_range[0], time_range[1])
+        indexers = {'time': time_slice}
+        return ds.sel(**indexers)
+    except TypeError:
+        raise ValueError('Time subset operation expects a dataset with the'
+                         ' time coordinate of type datetime64[ns], but received'
+                         ' {}. Running the normalize operation on this'
+                         ' dataset may help'.format(ds.time.dtype))
+
+
+def subset_temporal_index_impl(ds: xr.Dataset,
+                               time_ind_min: int,
+                               time_ind_max: int) -> xr.Dataset:
+    """
+    Do a temporal indices based subset
+
+    :param ds: Dataset or dataframe to subset
+    :param time_ind_min: Minimum time index to select
+    :param time_ind_max: Maximum time index to select
+    :return: Subset dataset
+    """
+    # we're creating a slice that includes both ends
+    # to have the same functionality as subset_temporal
+    time_slice = slice(time_ind_min, time_ind_max + 1)
+    indexers = {'time': time_slice}
+    return ds.isel(**indexers)

--- a/test/cli/test_cli.py
+++ b/test/cli/test_cli.py
@@ -282,7 +282,7 @@ class OperationCommandTest(CliTestCase):
         self.assert_main(['op', 'list'], expected_stdout=['operations found'])
         self.assert_main(['op', 'list', '-n', 'read'], expected_stdout=['operations found'])
         self.assert_main(['op', 'list', '-n', 'nevermatch'], expected_stdout=['No operations found'])
-        self.assert_main(['op', 'list', '--internal'], expected_stdout=['4 operations found'])
+        self.assert_main(['op', 'list', '--internal'], expected_stdout=['2 operations found'])
         self.assert_main(['op', 'list', '--tag', 'input'], expected_stdout=['8 operations found'])
         self.assert_main(['op', 'list', '--tag', 'output'], expected_stdout=['6 operations found'])
         self.assert_main(['op', 'list', '--deprecated'], expected_stdout=['No operations found'])

--- a/test/core/test_types.py
+++ b/test/core/test_types.py
@@ -500,9 +500,13 @@ class DatasetLikeTest(TestCase):
     def test_convert(self):
         self.assertEqual(DatasetLike.convert(None), None)
 
-        data = {'c1': [4, 5, 6], 'c2': [6, 7, 8]}
-        xr_ds = xr.Dataset(data_vars=data)
+        data = {'time': ['2000-01-01', '2000-01-02', '2000-01-03'],
+                'c1': [4, 5, 6],
+                'c2': [6, 7, 8]}
         pd_ds = pd.DataFrame(data=data)
+        pd_ds = pd_ds.set_index('time')
+        pd_ds.index = pd.to_datetime(pd_ds.index)
+        xr_ds = xr.Dataset(data_vars=data)
         self.assertIsInstance(DatasetLike.convert(xr_ds), xr.Dataset)
         self.assertIsInstance(DatasetLike.convert(pd_ds), xr.Dataset)
 

--- a/test/ops/test_aggregate.py
+++ b/test/ops/test_aggregate.py
@@ -13,6 +13,7 @@ from cate.util.misc import object_to_qualified_name
 from cate.util.monitor import ConsoleMonitor
 
 from cate.ops import long_term_average, temporal_aggregation
+from cate.ops import adjust_temporal_attrs
 
 
 class TestLTA(TestCase):
@@ -29,6 +30,8 @@ class TestLTA(TestCase):
             'lat': np.linspace(-88, 88, 45),
             'lon': np.linspace(-178, 178, 90),
             'time': pd.date_range('2000-01-01', freq='MS', periods=24)})
+
+        ds = adjust_temporal_attrs(ds)
 
         # Test monitor
         m = ConsoleMonitor()
@@ -62,6 +65,8 @@ class TestLTA(TestCase):
             'lon': np.linspace(-178, 178, 90),
             'time': pd.date_range('2000-01-01', freq='MS', periods=24)})
 
+        ds = adjust_temporal_attrs(ds)
+
         reg_op(ds=ds)
 
     def test_validation(self):
@@ -73,6 +78,8 @@ class TestLTA(TestCase):
             'lat': np.linspace(-88, 88, 45),
             'lon': np.linspace(-178, 178, 90)})
 
+        ds = adjust_temporal_attrs(ds)
+
         with self.assertRaises(ValueError) as err:
             long_term_average(ds)
         self.assertIn('normalize', str(err.exception))
@@ -82,6 +89,8 @@ class TestLTA(TestCase):
             'lat': np.linspace(-88, 88, 45),
             'lon': np.linspace(-178, 178, 90),
             'time': pd.date_range('2000-01-01', periods=24)})
+
+        ds = adjust_temporal_attrs(ds)
 
         with self.assertRaises(ValueError) as err:
             long_term_average(ds)
@@ -102,6 +111,8 @@ class TestTemporalAggregation(TestCase):
             'lat': np.linspace(-88, 88, 45),
             'lon': np.linspace(-178, 178, 90),
             'time': pd.date_range('2000-01-01', '2000-12-31')})
+        ds = adjust_temporal_attrs(ds)
+
         ex = xr.Dataset({
             'first': (['lat', 'lon', 'time'], np.ones([45, 90, 12])),
             'second': (['lat', 'lon', 'time'], np.ones([45, 90, 12])),
@@ -125,6 +136,8 @@ class TestTemporalAggregation(TestCase):
             'lat': np.linspace(-88, 88, 45),
             'lon': np.linspace(-178, 178, 90),
             'time': pd.date_range('2000-01-01', '2000-12-31')})
+        ds = adjust_temporal_attrs(ds)
+
         ex = xr.Dataset({
             'first': (['lat', 'lon', 'time'], np.ones([45, 90, 12])),
             'second': (['lat', 'lon', 'time'], np.ones([45, 90, 12])),
@@ -145,6 +158,7 @@ class TestTemporalAggregation(TestCase):
             'first': (['lat', 'lon', 'time'], np.ones([45, 90, 24])),
             'lat': np.linspace(-88, 88, 45),
             'lon': np.linspace(-178, 178, 90)})
+        ds = adjust_temporal_attrs(ds)
 
         with self.assertRaises(ValueError) as err:
             temporal_aggregation(ds)
@@ -155,6 +169,7 @@ class TestTemporalAggregation(TestCase):
             'lat': np.linspace(-88, 88, 45),
             'lon': np.linspace(-178, 178, 90),
             'time': pd.date_range('2000-01-01', freq='MS', periods=24)})
+        ds = adjust_temporal_attrs(ds)
 
         with self.assertRaises(ValueError) as err:
             temporal_aggregation(ds)

--- a/test/ops/test_aggregate.py
+++ b/test/ops/test_aggregate.py
@@ -122,7 +122,9 @@ class TestTemporalAggregation(TestCase):
         ex.first.attrs['cell_methods'] = 'time: mean within years'
         ex.second.attrs['cell_methods'] = 'time: mean within years'
 
-        actual = temporal_aggregation(ds)
+        m = ConsoleMonitor()
+        actual = temporal_aggregation(ds, monitor=m)
+
         self.assertTrue(actual.broadcast_equals(ex))
 
     def test_registered(self):


### PR DESCRIPTION
* Use global temporal attributes to check temporal resolution in aggregation operations
* Adjust temporal attributes automatically upon reading a dataset
* Refactor 'normalize' operation implementation logic to util/opimpl
* Adjust temporal attributes automatically upon DatasetLike.convert
* Refactor 'subset' operation implementation logic to util/opimpl

Closes #340 
Goes a long way in solving #318 