### PR TITLE
433 jg normalization error

### DIFF
--- a/cate/util/opimpl.py
+++ b/cate/util/opimpl.py
@@ -242,10 +242,28 @@ def _get_temporal_props(ds: xr.Dataset) -> dict:
     """
     ret = dict()
 
-    ret['time_coverage_start'] = str(ds.time.values[0])
-    ret['time_coverage_end'] = str(ds.time.values[-1])
-    ret['time_coverage_resolution'] = _get_temporal_res(ds.time.values)
-    ret['time_coverage_duration'] = _get_duration(ds.time.values)
+    try:
+        # According to CF conventions, the 'bounds' variable name should be in
+        # the attributes of the coordinate variable
+        bnds = ds['time'].attrs['bounds']
+        time_min = ds[bnds].values[0][0]
+        time_max = ds[bnds].values[-1][1]
+    except KeyError:
+        time_min = ds['time'].values[0]
+        time_max = ds['time'].values[-1]
+
+    if time_min != time_max:
+        ret['time_coverage_duration'] = _get_duration(time_min, time_max)
+    else:
+        ret['time_coverage_duration'] = None
+
+    if ds['time'].values[0] == ds['time'].values[-1]:
+        ret['time_coverage_resolution'] = None
+    else:
+        ret['time_coverage_resolution'] = _get_temporal_res(ds.time.values)
+
+    ret['time_coverage_start'] = str(time_min)
+    ret['time_coverage_end'] = str(time_max)
 
     return ret
 
@@ -315,17 +333,19 @@ def _get_temporal_res(time: np.ndarray) -> str:
         return 'P{}D'.format(int(days))
 
 
-def _get_duration(time: np.ndarray) -> str:
+def _get_duration(tmin: np.datetime64, tmax: np.datetime64) -> str:
     """
-    Determine the duration of the given datetimes array.
+    Determine the duration of the given datetimes.
 
     See also: `ISO 8601 Durations <https://en.wikipedia.org/wiki/ISO_8601#Durations>`_
 
-    :param time: A numpy array containing np.datetime64 objects
+    :param tmin: Time minimum
+    :param tmax: Time maximum
     :return: Temporal resolution formatted as an ISO 8601:2004 duration string
     """
-    delta = time[-1] - time[0]
-    days = delta.astype('timedelta64[D]') / np.timedelta64(1, 'D')
+    delta = tmax - tmin
+    day = np.timedelta64(1, 'D')
+    days = (delta.astype('timedelta64[D]') / day) + 1
     return 'P{}D'.format(int(days))
 
 

--- a/cate/util/opimpl.py
+++ b/cate/util/opimpl.py
@@ -219,12 +219,35 @@ def adjust_temporal_attrs_impl(ds: xr.Dataset) -> xr.Dataset:
     """
     ds = ds.copy()
 
-    ds.attrs['time_coverage_start'] = str(ds.time.values[0])
-    ds.attrs['time_coverage_end'] = str(ds.time.values[-1])
-    ds.attrs['time_coverage_resolution'] = _get_temporal_res(ds.time.values)
-    ds.attrs['time_coverage_duration'] = _get_duration(ds.time.values)
+    tempattrs = _get_temporal_props(ds)
+
+    for key in tempattrs:
+        if tempattrs[key] is not None:
+            ds.attrs[key] = tempattrs[key]
+        else:
+            ds.attrs.pop(key, None)
 
     return ds
+
+
+def _get_temporal_props(ds: xr.Dataset) -> dict:
+    """
+    Get temporal boundaries, resolution and duration of the given dataset. If
+    the 'bounds' are explicitly defined, these will be used for calculation,
+    otherwise it will rest on information gathered from the 'time' dimension
+    itself.
+
+    :param ds: Dataset
+    :return: A dictionary {'attr_name': attr_value}
+    """
+    ret = dict()
+
+    ret['time_coverage_start'] = str(ds.time.values[0])
+    ret['time_coverage_end'] = str(ds.time.values[-1])
+    ret['time_coverage_resolution'] = _get_temporal_res(ds.time.values)
+    ret['time_coverage_duration'] = _get_duration(ds.time.values)
+
+    return ret
 
 
 def _get_spatial_props(ds: xr.Dataset, dim: str) -> dict:

--- a/test/ops/test_normalize.py
+++ b/test/ops/test_normalize.py
@@ -284,7 +284,7 @@ class TestAdjustTemporal(TestCase):
         self.assertEqual(ds1.attrs['time_coverage_resolution'],
                          'P1M')
         self.assertEqual(ds1.attrs['time_coverage_duration'],
-                         'P335D')
+                         'P336D')
 
         # Test existing attributes update
         indexers = {'time': slice(datetime(2000, 2, 15), datetime(2000, 6, 15))}
@@ -298,7 +298,7 @@ class TestAdjustTemporal(TestCase):
         self.assertEqual(ds2.attrs['time_coverage_resolution'],
                          'P1M')
         self.assertEqual(ds2.attrs['time_coverage_duration'],
-                         'P92D')
+                         'P93D')
 
     def test_bnds(self):
         """Test a case when time_bnds is available"""
@@ -331,11 +331,11 @@ class TestAdjustTemporal(TestCase):
         self.assertEqual(ds1.attrs['time_coverage_start'],
                          '2000-01-01T00:00:00.000000000')
         self.assertEqual(ds1.attrs['time_coverage_end'],
-                         '2000-12-31:00:00.000000000')
+                         '2000-12-31T00:00:00.000000000')
         self.assertEqual(ds1.attrs['time_coverage_resolution'],
                          'P1M')
         self.assertEqual(ds1.attrs['time_coverage_duration'],
-                         'P365D')
+                         'P366D')
 
     def test_single_slice(self):
         """Test a case when the dataset is a single time slice"""
@@ -362,10 +362,11 @@ class TestAdjustTemporal(TestCase):
                          '2000-01-01T00:00:00.000000000')
         self.assertEqual(ds1.attrs['time_coverage_end'],
                          '2000-01-31T00:00:00.000000000')
-        self.assertEqual(ds1.attrs['time_coverage_resolution'],
-                         'P1M')
         self.assertEqual(ds1.attrs['time_coverage_duration'],
                          'P31D')
+        with self.assertRaises(KeyError):
+            # Resolution is not defined for a single slice
+            ds.attrs['time_coverage_resolution']
 
         # Without bnds
         ds = xr.Dataset({
@@ -380,7 +381,7 @@ class TestAdjustTemporal(TestCase):
         self.assertEqual(ds1.attrs['time_coverage_start'],
                          '2000-01-01T00:00:00.000000000')
         self.assertEqual(ds1.attrs['time_coverage_end'],
-                         '2000-01-01:00:00.000000000')
+                         '2000-01-01T00:00:00.000000000')
         with self.assertRaises(KeyError):
             ds.attrs['time_coverage_resolution']
         with self.assertRaises(KeyError):

--- a/test/ops/test_normalize.py
+++ b/test/ops/test_normalize.py
@@ -8,6 +8,7 @@ import xarray as xr
 from jdcal import gcal2jd
 import numpy as np
 from datetime import datetime
+import calendar
 
 from cate.ops.normalize import normalize, adjust_spatial_attrs, adjust_temporal_attrs
 from cate.core.op import OP_REGISTRY
@@ -298,3 +299,100 @@ class TestAdjustTemporal(TestCase):
                          'P1M')
         self.assertEqual(ds2.attrs['time_coverage_duration'],
                          'P92D')
+
+    def test_bnds(self):
+        """Test a case when time_bnds is available"""
+        ds = xr.Dataset({
+            'first': (['lat', 'lon', 'time'], np.zeros([45, 90, 12])),
+            'second': (['lat', 'lon', 'time'], np.zeros([45, 90, 12])),
+            'lat': np.linspace(-88, 88, 45),
+            'lon': np.linspace(-178, 178, 90),
+            'time': [datetime(2000, x, 1) for x in range(1, 13)]})
+
+        month_ends = list()
+        for x in ds.time.values:
+            year = int(str(x)[0:4])
+            month = int(str(x)[5:7])
+            day = calendar.monthrange(year, month)[1]
+            month_ends.append(datetime(year, month, day))
+
+        time_bnds = np.empty([len(ds.time), 2])
+        time_bnds[:, 0] = ds.time.values
+        time_bnds[:, 1] = month_ends
+
+        ds['nv'] = [0, 1]
+        ds['time_bnds'] = (['time', 'nv'], time_bnds)
+        ds.time.attrs['bounds'] = 'time_bnds'
+
+        ds1 = adjust_temporal_attrs(ds)
+
+        # Make sure original dataset is not altered
+        with self.assertRaises(KeyError):
+            ds.attrs['time_coverage_start']
+
+        # Make sure expected values are in the new dataset
+        self.assertEqual(ds1.attrs['time_coverage_start'],
+                         '2000-01-01T00:00:00.000000000')
+        self.assertEqual(ds1.attrs['time_coverage_end'],
+                         '2000-12-31:00:00.000000000')
+        self.assertEqual(ds1.attrs['time_coverage_resolution'],
+                         'P1M')
+        self.assertEqual(ds1.attrs['time_coverage_duration'],
+                         'P365D')
+
+    def test_single_slice(self):
+        """Test a case when the dataset is a single time slice"""
+        # With bnds
+        ds = xr.Dataset({
+            'first': (['lat', 'lon', 'time'], np.zeros([45, 90, 12])),
+            'second': (['lat', 'lon', 'time'], np.zeros([45, 90, 12])),
+            'lat': np.linspace(-88, 88, 45),
+            'lon': np.linspace(-178, 178, 90),
+            'time': [datetime(2000, 1, 1)]})
+
+        year = int(str(ds.time.values[0])[0:4])
+        month = int(str(ds.time.values[0])[5:7])
+        day = calendar.monthrange(year, month)[1]
+
+        time_bnds = np.empty([1, 2])
+        time_bnds[0, 0] = ds.time.values[0]
+        time_bnds[0, 1] = datetime(year, month, day)
+
+        ds['nv'] = [0, 1]
+        ds['time_bnds'] = (['time', 'nv'], time_bnds)
+        ds.time.attrs['bounds'] = 'time_bnds'
+
+        ds1 = adjust_temporal_attrs(ds)
+
+        # Make sure original dataset is not altered
+        with self.assertRaises(KeyError):
+            ds.attrs['time_coverage_start']
+
+        # Make sure expected values are in the new dataset
+        self.assertEqual(ds1.attrs['time_coverage_start'],
+                         '2000-01-01T00:00:00.000000000')
+        self.assertEqual(ds1.attrs['time_coverage_end'],
+                         '2000-01-31T00:00:00.000000000')
+        self.assertEqual(ds1.attrs['time_coverage_resolution'],
+                         'P1M')
+        self.assertEqual(ds1.attrs['time_coverage_duration'],
+                         'P31D')
+
+        # Without bnds
+        ds = xr.Dataset({
+            'first': (['lat', 'lon', 'time'], np.zeros([45, 90, 12])),
+            'second': (['lat', 'lon', 'time'], np.zeros([45, 90, 12])),
+            'lat': np.linspace(-88, 88, 45),
+            'lon': np.linspace(-178, 178, 90),
+            'time': [datetime(2000, 1, 1)]})
+
+        ds1 = adjust_temporal_attrs(ds)
+
+        self.assertEqual(ds1.attrs['time_coverage_start'],
+                         '2000-01-01T00:00:00.000000000')
+        self.assertEqual(ds1.attrs['time_coverage_end'],
+                         '2000-01-01:00:00.000000000')
+        with self.assertRaises(KeyError):
+            ds.attrs['time_coverage_resolution']
+        with self.assertRaises(KeyError):
+            ds.attrs['time_coverage_duration']

--- a/test/ops/test_normalize.py
+++ b/test/ops/test_normalize.py
@@ -302,12 +302,14 @@ class TestAdjustTemporal(TestCase):
 
     def test_bnds(self):
         """Test a case when time_bnds is available"""
+        time = [datetime(2000, x, 1) for x in range(1, 13)]
         ds = xr.Dataset({
             'first': (['lat', 'lon', 'time'], np.zeros([45, 90, 12])),
             'second': (['lat', 'lon', 'time'], np.zeros([45, 90, 12])),
             'lat': np.linspace(-88, 88, 45),
             'lon': np.linspace(-178, 178, 90),
-            'time': [datetime(2000, x, 1) for x in range(1, 13)]})
+            'nv': [0, 1],
+            'time': time})
 
         month_ends = list()
         for x in ds.time.values:
@@ -316,12 +318,7 @@ class TestAdjustTemporal(TestCase):
             day = calendar.monthrange(year, month)[1]
             month_ends.append(datetime(year, month, day))
 
-        time_bnds = np.empty([len(ds.time), 2])
-        time_bnds[:, 0] = ds.time.values
-        time_bnds[:, 1] = month_ends
-
-        ds['nv'] = [0, 1]
-        ds['time_bnds'] = (['time', 'nv'], time_bnds)
+        ds['time_bnds'] = (['time', 'nv'], list(zip(time, month_ends)))
         ds.time.attrs['bounds'] = 'time_bnds'
 
         ds1 = adjust_temporal_attrs(ds)
@@ -344,23 +341,15 @@ class TestAdjustTemporal(TestCase):
         """Test a case when the dataset is a single time slice"""
         # With bnds
         ds = xr.Dataset({
-            'first': (['lat', 'lon', 'time'], np.zeros([45, 90, 12])),
-            'second': (['lat', 'lon', 'time'], np.zeros([45, 90, 12])),
+            'first': (['lat', 'lon', 'time'], np.zeros([45, 90, 1])),
+            'second': (['lat', 'lon', 'time'], np.zeros([45, 90, 1])),
             'lat': np.linspace(-88, 88, 45),
             'lon': np.linspace(-178, 178, 90),
+            'nv': [0, 1],
             'time': [datetime(2000, 1, 1)]})
-
-        year = int(str(ds.time.values[0])[0:4])
-        month = int(str(ds.time.values[0])[5:7])
-        day = calendar.monthrange(year, month)[1]
-
-        time_bnds = np.empty([1, 2])
-        time_bnds[0, 0] = ds.time.values[0]
-        time_bnds[0, 1] = datetime(year, month, day)
-
-        ds['nv'] = [0, 1]
-        ds['time_bnds'] = (['time', 'nv'], time_bnds)
         ds.time.attrs['bounds'] = 'time_bnds'
+        ds['time_bnds'] = (['time', 'nv'],
+                           [(datetime(2000, 1, 1), datetime(2000, 1, 31))])
 
         ds1 = adjust_temporal_attrs(ds)
 
@@ -380,8 +369,8 @@ class TestAdjustTemporal(TestCase):
 
         # Without bnds
         ds = xr.Dataset({
-            'first': (['lat', 'lon', 'time'], np.zeros([45, 90, 12])),
-            'second': (['lat', 'lon', 'time'], np.zeros([45, 90, 12])),
+            'first': (['lat', 'lon', 'time'], np.zeros([45, 90, 1])),
+            'second': (['lat', 'lon', 'time'], np.zeros([45, 90, 1])),
             'lat': np.linspace(-88, 88, 45),
             'lon': np.linspace(-178, 178, 90),
             'time': [datetime(2000, 1, 1)]})


### PR DESCRIPTION
Temporal attribute normalization now uses the 'time_bnds' variable, if one is defined in the dataset.
It also handles datasets consisting of a single time slice.

Closes #433 