### PR TITLE
58 nf speedup cli

### DIFF
--- a/cate/cli/main.py
+++ b/cate/cli/main.py
@@ -1288,6 +1288,52 @@ class DataSourceCommand(SubCommandCommand):
             print("Local data source not created. It would have been empty. Please check constraint.")
 
 
+class IOCommand(SubCommandCommand):
+    """
+    The ``io`` command implements various operations w.r.t. supported data and file formats.
+    """
+
+    @classmethod
+    def name(cls):
+        return 'io'
+
+    @classmethod
+    def parser_kwargs(cls):
+        return dict(help='Manage supported data and file formats.')
+
+    @classmethod
+    def configure_parser_and_subparsers(cls, parser, subparsers):
+        list_parser = subparsers.add_parser('list', help='List all supported file or data formats')
+        list_parser.add_argument('--read', '-r', action='store_true',
+                                 help="List only file/data formats that can be read.")
+        list_parser.add_argument('--write', '-w', action='store_true',
+                                 help="List only file/data formats that can be written.")
+        list_parser.set_defaults(sub_command_function=cls._execute_list)
+
+    # noinspection PyShadowingNames
+    @classmethod
+    def _execute_list(cls, command_args):
+        from cate.core.objectio import OBJECT_IO_REGISTRY
+
+        if command_args.read and command_args.write:
+            object_io_list = OBJECT_IO_REGISTRY.get_object_io_list(mode='rw')
+        elif command_args.read:
+            object_io_list = OBJECT_IO_REGISTRY.get_object_io_list(mode='r')
+        elif command_args.write:
+            object_io_list = OBJECT_IO_REGISTRY.get_object_io_list(mode='w')
+        else:
+            object_io_list = OBJECT_IO_REGISTRY.get_object_io_list()
+
+        if not object_io_list:
+            print('No formats found.')
+            return
+
+        for object_io in object_io_list:
+            print('{name} (*{ext}) - {desc}'.format(name=object_io.format_name,
+                                                    ext=object_io.filename_ext,
+                                                    desc=object_io.description))
+
+
 class PluginCommand(SubCommandCommand):
     """
     The ``pi`` command lists the content of various plugin registry.
@@ -1331,6 +1377,7 @@ COMMAND_REGISTRY = [
     WorkspaceCommand,
     ResourceCommand,
     RunCommand,
+    IOCommand,
     # PluginCommand,
 ]
 

--- a/cate/core/ds.py
+++ b/cate/core/ds.py
@@ -88,7 +88,7 @@ import xarray as xr
 
 from .cdm import Schema, get_lon_dim_name, get_lat_dim_name
 from .types import PolygonLike, TimeRange, TimeRangeLike, VarNamesLike
-from ..util import Monitor
+from ..util.monitor import Monitor
 
 __author__ = "Norman Fomferra (Brockmann Consult GmbH), " \
              "Marco Zühlke (Brockmann Consult GmbH), " \

--- a/cate/core/objectio.py
+++ b/cate/core/objectio.py
@@ -33,7 +33,7 @@ from abc import ABCMeta, abstractmethod
 from collections import OrderedDict
 
 from .op import Operation
-from ..util import Monitor
+from ..util.monitor import Monitor
 
 
 __author__ = "Norman Fomferra (Brockmann Consult GmbH)"
@@ -114,6 +114,19 @@ class ObjectIORegistry:
     @property
     def object_io_list(self):
         return self._object_io_list
+
+    def get_object_io_list(self, mode=None):
+        if mode and mode not in ['r', 'w', 'rw']:
+            raise ValueError('illegal mode')
+        object_io_list = []
+        for object_io in self._object_io_list:
+            is_reader = object_io.read_op is not None
+            is_writer = object_io.write_op is not None
+            if not mode or (mode == 'r' and is_reader) or (mode == 'w' and is_writer) or (
+                                mode == 'rw' and is_reader and is_writer):
+                object_io_list.append(object_io)
+        # noinspection PyShadowingNames
+        return sorted(object_io_list, key=lambda object_io: object_io.format_name)
 
     def get_format_names(self, mode=None):
         if mode and mode not in ['r', 'w', 'rw']:

--- a/cate/core/op.py
+++ b/cate/core/op.py
@@ -110,9 +110,13 @@ from typing import Union, Callable, Optional, Dict
 
 import xarray as xr
 
-from ..util import OpMetaInfo, object_to_qualified_name, Monitor, UNDEFINED, safe_eval
+from ..util.opmetainf import OpMetaInfo
+from ..util.monitor import Monitor
+from ..util.undefined import UNDEFINED
+from ..util.safe import safe_eval
 from ..util.process import run_subprocess, ProcessOutputMonitor
 from ..util.tmpfile import new_temp_file, del_temp_file
+from ..util.misc import object_to_qualified_name
 from ..version import __version__
 
 __author__ = "Norman Fomferra (Brockmann Consult GmbH)"

--- a/cate/core/types.py
+++ b/cate/core/types.py
@@ -47,8 +47,9 @@ from shapely import wkt
 from shapely.geometry import Point, Polygon, box
 from shapely.geometry.base import BaseGeometry
 
-from ..util import safe_eval, to_list, to_datetime_range, to_datetime
-from cate.util.opimpl import adjust_temporal_attrs_impl
+from ..util.safe import safe_eval
+from ..util.misc import to_list, to_datetime_range, to_datetime
+from ..util.opimpl import adjust_temporal_attrs_impl
 
 __author__ = "Janis Gailis (S[&]T Norway), " \
              "Norman Fomferra (Brockmann Consult GmbH), " \

--- a/cate/core/workflow.py
+++ b/cate/core/workflow.py
@@ -120,7 +120,10 @@ from itertools import chain
 from typing import Optional, Union, List, Dict
 
 from .op import OP_REGISTRY, Operation, Monitor, new_expression_op, new_subprocess_op
-from ..util import Namespace, UNDEFINED, safe_eval, OpMetaInfo
+from ..util.namespace import Namespace
+from ..util.undefined import UNDEFINED
+from ..util.safe import safe_eval
+from ..util.opmetainf import OpMetaInfo
 
 __author__ = "Norman Fomferra (Brockmann Consult GmbH)"
 

--- a/cate/core/workspace.py
+++ b/cate/core/workspace.py
@@ -39,9 +39,13 @@ from ..conf import conf
 from ..conf.defaults import WORKSPACE_DATA_DIR_NAME, WORKSPACE_WORKFLOW_FILE_NAME, SCRATCH_WORKSPACES_PATH
 from ..core.cdm import get_tiling_scheme
 from ..core.op import OP_REGISTRY
-from ..util import Monitor, Namespace, object_to_qualified_name, to_json, safe_eval, UNDEFINED, new_indexed_name
+from ..util.monitor import Monitor
+from ..util.misc import object_to_qualified_name, to_json, new_indexed_name
+from ..util.safe import safe_eval
+from ..util.undefined import UNDEFINED
 from ..util.im import get_chunk_size
 from ..util.opmetainf import OpMetaInfo
+from ..util.namespace import Namespace
 
 __author__ = "Norman Fomferra (Brockmann Consult GmbH)"
 
@@ -323,7 +327,7 @@ class Workspace:
             for var_name in var_names:
                 variable = resource[var_name]
                 variable_descriptors.append(self._get_pandas_variable_descriptor(variable))
-            # noinspection PyArgumentList
+            # noinspection PyArgumentList,PyTypeChecker
             resource_json.update(variables=variable_descriptors)
 
         elif isinstance(resource, fiona.Collection):
@@ -360,6 +364,7 @@ class Workspace:
             'shape': variable.shape,
         }
 
+    # noinspection PyMethodMayBeStatic
     def _get_xarray_variable_descriptor(self, variable: xr.DataArray, is_coord=False):
         attrs = variable.attrs
         variable_info = {

--- a/cate/core/wsmanag.py
+++ b/cate/core/wsmanag.py
@@ -31,7 +31,9 @@ from .objectio import write_object
 from .workflow import Workflow
 from .workspace import Workspace, WorkspaceError, OpKwArgs
 from ..conf.defaults import SCRATCH_WORKSPACES_PATH
-from ..util import UNDEFINED, Monitor, safe_eval
+from ..util.monitor import Monitor
+from ..util.safe import safe_eval
+from ..util.undefined import UNDEFINED
 
 __author__ = "Norman Fomferra (Brockmann Consult GmbH)"
 

--- a/cate/ds/esa_cci_ftp.py
+++ b/cate/ds/esa_cci_ftp.py
@@ -54,7 +54,8 @@ from cate.conf.conf import get_data_stores_path
 from cate.core.cdm import Schema
 from cate.core.ds import DataStore, DataSource, open_xarray_dataset, DATA_STORE_REGISTRY
 from cate.core.types import PolygonLike, TimeRangeLike, VarNamesLike
-from cate.util import to_datetime, Monitor, Cancellation
+from cate.util.misc import to_datetime
+from cate.util.monitor import Monitor, Cancellation
 
 __author__ = "Norman Fomferra (Brockmann Consult GmbH), " \
              "Marco Zühlke (Brockmann Consult GmbH), " \
@@ -327,17 +328,17 @@ class _DownloadStatistics:
     def handle_chunk(self, bytes):
         self.bytes_done += bytes
 
-    def asMB(self, bytes):
-        return bytes / (1024 * 1024)
+    def as_mb(self, bytes):
+        return bytes / (1000 * 1000)
 
     def __str__(self):
         seconds = (datetime.now() - self.startTime).seconds
         if seconds > 0:
-            mb_per_sec = self.asMB(self.bytes_done) / seconds
+            mb_per_sec = self.as_mb(self.bytes_done) / seconds
         else:
             mb_per_sec = 0
         return "%d of %d MB, speed %.3f MB/s" % \
-               (self.asMB(self.bytes_done), self.asMB(self.bytes_total), mb_per_sec)
+               (self.as_mb(self.bytes_done), self.as_mb(self.bytes_total), mb_per_sec)
 
 
 class FtpDownloader:

--- a/cate/ops/coregistration.py
+++ b/cate/ops/coregistration.py
@@ -38,7 +38,7 @@ import numpy as np
 import xarray as xr
 
 from cate.core.op import op_input, op, op_return
-from cate.util import Monitor
+from cate.util.monitor import Monitor
 
 from cate.ops import resampling
 from cate.ops.normalize import adjust_spatial_attrs

--- a/cate/ops/correlation.py
+++ b/cate/ops/correlation.py
@@ -38,7 +38,7 @@ from scipy.special import betainc
 
 from cate.core.op import op, op_input, op_return
 from cate.core.types import VarName, DatasetLike
-from cate.util import Monitor
+from cate.util.monitor import Monitor
 
 from cate.ops.normalize import adjust_spatial_attrs
 

--- a/cate/ops/index.py
+++ b/cate/ops/index.py
@@ -37,7 +37,7 @@ from cate.ops.select import select_var
 from cate.ops.subset import subset_spatial
 from cate.ops.anomaly import anomaly_external
 from cate.core.types import PolygonLike, VarName
-from cate.util import Monitor
+from cate.util.monitor import Monitor
 
 
 _ALL_FILE_FILTER = dict(name='All Files', extensions=['*'])

--- a/cate/ops/io.py
+++ b/cate/ops/io.py
@@ -33,7 +33,7 @@ from cate.core.op import OP_REGISTRY, op_input, op
 from cate.core.types import VarNamesLike, TimeRangeLike, PolygonLike, DictLike, FileLike
 from cate.ops.normalize import normalize as normalize_op
 from cate.ops.normalize import adjust_temporal_attrs
-from cate.util import Monitor
+from cate.util.monitor import Monitor
 
 _ALL_FILE_FILTER = dict(name='All Files', extensions=['*'])
 

--- a/cate/ops/outliers.py
+++ b/cate/ops/outliers.py
@@ -34,7 +34,7 @@ import numpy as np
 
 from cate.core.op import op, op_input, op_return
 from cate.core.types import VarNamesLike, DatasetLike
-from cate.util import Monitor
+from cate.util.monitor import Monitor
 from cate import __version__
 
 

--- a/cate/ops/timeseries.py
+++ b/cate/ops/timeseries.py
@@ -34,7 +34,7 @@ import xarray as xr
 from cate.core.op import op_input, op, op_return
 from cate.ops.select import select_var
 from cate.core.types import VarNamesLike, PointLike
-from cate.util import Monitor
+from cate.util.monitor import Monitor
 
 
 @op(tags=['timeseries', 'temporal', 'filter', 'point'], version='1.0')

--- a/cate/ops/utility.py
+++ b/cate/ops/utility.py
@@ -34,7 +34,7 @@ import xarray as xr
 
 from cate.core.op import op, op_input, op_return
 from cate.core.types import DatasetLike, PointLike, TimeLike, DictLike, Arbitrary, Literal
-from cate.util import Monitor
+from cate.util.monitor import Monitor
 
 
 @op(tags=['utility', 'internal'])

--- a/cate/util/__init__.py
+++ b/cate/util/__init__.py
@@ -19,8 +19,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-__author__ = "Norman Fomferra (Brockmann Consult GmbH)"
-
 """
 Description
 ===========
@@ -40,13 +38,4 @@ Components
 ==========
 """
 
-from .extend import extend
-from .misc import *
-from .monitor import Monitor, ChildMonitor, ConsoleMonitor, Cancellation
-from .namespace import Namespace
-from .opmetainf import OpMetaInfo
-from .undefined import UNDEFINED
-from .safe import safe_eval, get_safe_globals
-from .process import run_subprocess, ProcessOutputMonitor
-from .tmpfile import new_temp_file, del_temp_file, del_temp_files
-from .opimpl import normalize_impl, adjust_temporal_attrs_impl, adjust_spatial_attrs_impl
+__author__ = "Norman Fomferra (Brockmann Consult GmbH)"

--- a/cate/util/cache.py
+++ b/cate/util/cache.py
@@ -19,7 +19,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-__author__ = "Norman Fomferra (Brockmann Consult GmbH)"
 
 """
 Description
@@ -55,6 +54,8 @@ import sys
 import time
 from abc import ABCMeta, abstractmethod
 from threading import RLock
+
+__author__ = "Norman Fomferra (Brockmann Consult GmbH)"
 
 # _DEBUG_CACHE = True
 _DEBUG_CACHE = False

--- a/cate/util/cli.py
+++ b/cate/util/cli.py
@@ -37,7 +37,7 @@ import traceback
 from abc import ABCMeta, abstractmethod
 from typing import Sequence
 
-from cate.util import ConsoleMonitor, Monitor
+from .monitor import ConsoleMonitor, Monitor
 
 
 class CommandError(Exception):

--- a/cate/util/monitor.py
+++ b/cate/util/monitor.py
@@ -19,8 +19,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-__author__ = "Norman Fomferra (Brockmann Consult GmbH)"
-
 """
 Description
 ===========
@@ -34,20 +32,18 @@ prints progress output directly to the console.
 Components
 ==========
 """
+
 import signal
 import sys
 from abc import ABCMeta, abstractmethod
 from contextlib import contextmanager
 from shutil import get_terminal_size
 
-try:
-    from dask.callbacks import Callback
-
-    _has_dask = True
-except ImportError:
-    _has_dask = False
+__author__ = "Norman Fomferra (Brockmann Consult GmbH)"
 
 _DEBUG_DASK_PROGRESS = False
+_DaskMonitor = None
+_IS_DASK_AVAILABLE = None
 
 
 class Cancellation(Exception):
@@ -117,11 +113,12 @@ class Monitor(metaclass=ABCMeta):
         :param label: Passed to the monitor's ``start`` method
         :return:
         """
-        if _has_dask:
-            with _DaskMonitor(label=label, monitor=self):
+        dask_monitor = _get_dask_monitor()
+        if dask_monitor is not None:
+            with dask_monitor(label=label, monitor=self):
                 yield
         else:
-            raise NotImplementedError("dask could not be loaded.")
+            raise NotImplementedError('Monitor.observing() requires "dask" package to be installed')
 
     @abstractmethod
     def start(self, label: str, total_work: float = None):
@@ -193,6 +190,7 @@ class Monitor(metaclass=ABCMeta):
             raise Cancellation()
 
 
+# noinspection PyAbstractClass
 class _NullMonitor(Monitor):
     def __repr__(self):
         # Overridden to make Sphinx use a readable name.
@@ -215,6 +213,7 @@ class _NullMonitor(Monitor):
 Monitor.NONE = _NullMonitor()
 
 
+# noinspection PyAbstractClass
 class ChildMonitor(Monitor):
     """
     A child monitor is responsible for a partial amount of work of a *parent_monitor*.
@@ -366,6 +365,7 @@ class ConsoleMonitor(Monitor):
     def _on_ctrl_c(self, signal, frame):
         self.cancel()
 
+    # noinspection PyMethodMayBeStatic
     def _register_ctrl_c_handler(self, ctrl_c_handler):
         if ctrl_c_handler:
             try:
@@ -375,33 +375,51 @@ class ConsoleMonitor(Monitor):
                 pass
 
 
-if _has_dask:
-    class _DaskMonitor(Callback):
-        """
-        A ``dask.Callback`` that reports the task level notification that the
-        dask scheduler generates to the provided ``Monitor``.
+def _get_dask_monitor():
+    global _DaskMonitor
+    global _IS_DASK_AVAILABLE
 
-        This allows for tracking then progress inside dask compute/get calls and
-        the possibility to cancel them.
-        """
+    if _DaskMonitor is None and _IS_DASK_AVAILABLE is None:
+        try:
+            # noinspection PyUnresolvedReferences,PyPackageRequirements
+            from dask.callbacks import Callback
 
-        def __init__(self, label: str, monitor: Monitor):
-            super().__init__()
-            self._label = label
-            self._monitor = monitor
+            _IS_DASK_AVAILABLE = True
 
-        def _start_state(self, dsk, state):
-            num_tasks = sum(len(state[k]) for k in ['ready', 'waiting'])
-            self._monitor.start(label=self._label, total_work=num_tasks)
-            if _DEBUG_DASK_PROGRESS:
-                print("DaskMonitor.start_state: num_tasks=", num_tasks)
+            class _DaskMonitor(Callback):
+                """
+                A ``dask.Callback`` that reports the task level notification that the
+                dask scheduler generates to the provided ``Monitor``.
 
-        def _posttask(self, key, result, dsk, state, worker_id):
-            self._monitor.progress(work=1)
-            if _DEBUG_DASK_PROGRESS:
-                print("DaskMonitor.posttask: key=", key)
+                This allows for tracking then progress inside dask compute/get calls and
+                the possibility to cancel them.
+                """
 
-        def _finish(self, dsk, state, failed):
-            self._monitor.done()
-            if _DEBUG_DASK_PROGRESS:
-                print("DaskMonitor.finish")
+                def __init__(self, label: str, monitor: Monitor):
+                    super().__init__()
+                    self._label = label
+                    self._monitor = monitor
+
+                # noinspection PyUnusedLocal
+                def _start_state(self, dsk, state):
+                    num_tasks = sum(len(state[k]) for k in ['ready', 'waiting'])
+                    self._monitor.start(label=self._label, total_work=num_tasks)
+                    if _DEBUG_DASK_PROGRESS:
+                        print("DaskMonitor.start_state: num_tasks=", num_tasks)
+
+                # noinspection PyUnusedLocal
+                def _posttask(self, key, result, dsk, state, worker_id):
+                    self._monitor.progress(work=1)
+                    if _DEBUG_DASK_PROGRESS:
+                        print("DaskMonitor.posttask: key=", key)
+
+                # noinspection PyUnusedLocal
+                def _finish(self, dsk, state, failed):
+                    self._monitor.done()
+                    if _DEBUG_DASK_PROGRESS:
+                        print("DaskMonitor.finish")
+
+        except ImportError:
+            _IS_DASK_AVAILABLE = False
+
+    return _DaskMonitor

--- a/cate/util/process.py
+++ b/cate/util/process.py
@@ -27,7 +27,7 @@ import shlex
 import time
 from typing import Callable, Optional, Tuple, Union, Dict, Sequence
 
-from . import Monitor
+from .monitor import Monitor
 
 __author__ = "Norman Fomferra (Brockmann Consult GmbH)"
 

--- a/cate/util/web/jsonrpcmonitor.py
+++ b/cate/util/web/jsonrpcmonitor.py
@@ -26,7 +26,7 @@ import time
 
 import tornado.websocket
 
-from cate.util import Monitor
+from cate.util.monitor import Monitor
 
 
 class JsonRpcWebSocketMonitor(Monitor):

--- a/cate/webapi/rest.py
+++ b/cate/webapi/rest.py
@@ -43,8 +43,7 @@ from ..conf.defaults import \
     WEBAPI_ON_ALL_CLOSED_AUTO_STOP_AFTER, \
     WEBAPI_USE_WORKSPACE_IMAGERY_CACHE
 from ..core.cdm import get_tiling_scheme
-from ..util import ConsoleMonitor
-from ..util import Monitor
+from ..util.monitor import Monitor, ConsoleMonitor
 from ..util.cache import Cache, MemoryCacheStore, FileCacheStore
 from ..util.im import ImagePyramid, TransformArrayImage, ColorMappedRgbaImage
 from ..util.im.ds import NaturalEarth2Image

--- a/cate/webapi/websocket.py
+++ b/cate/webapi/websocket.py
@@ -30,7 +30,8 @@ from cate.core.ds import DATA_STORE_REGISTRY
 from cate.core.op import OP_REGISTRY
 from cate.core.workspace import OpKwArgs
 from cate.core.wsmanag import WorkspaceManager
-from cate.util import Monitor, cwd, filter_fileset
+from cate.util.monitor import Monitor
+from cate.util.misc import cwd, filter_fileset
 
 __author__ = "Norman Fomferra (Brockmann Consult GmbH), " \
              "Marco Zühlke (Brockmann Consult GmbH)"

--- a/cate/webapi/wsmanag.py
+++ b/cate/webapi/wsmanag.py
@@ -30,7 +30,8 @@ from tornado import gen, ioloop, websocket
 from cate.conf.defaults import WEBAPI_WORKSPACE_TIMEOUT, WEBAPI_RESOURCE_TIMEOUT, WEBAPI_PLOT_TIMEOUT
 from cate.core.workspace import Workspace, WorkspaceError, OpKwArgs
 from cate.core.wsmanag import WorkspaceManager
-from cate.util import encode_url_path, Monitor
+from cate.util.misc import encode_url_path
+from cate.util.monitor import Monitor
 
 __author__ = "Norman Fomferra (Brockmann Consult GmbH)"
 

--- a/test/core/test_ds.py
+++ b/test/core/test_ds.py
@@ -8,7 +8,7 @@ import xarray as xr
 
 import cate.core.ds as ds
 from cate.core.types import PolygonLike, TimeRangeLike, VarNamesLike
-from cate.util import Monitor
+from cate.util.monitor import Monitor
 
 _TEST_DATA_PATH = op.join(op.dirname(op.realpath(__file__)), 'test_data')
 

--- a/test/core/test_types.py
+++ b/test/core/test_types.py
@@ -13,7 +13,7 @@ from shapely.geometry import Point, Polygon
 from cate.core.op import op_input, OpRegistry
 from cate.core.types import Like, VarNamesLike, VarName, PointLike, PolygonLike, TimeRangeLike, GeometryLike, DictLike, \
     TimeLike, Arbitrary, Literal, DatasetLike, DataFrameLike, FileLike
-from cate.util import object_to_qualified_name, OrderedDict
+from cate.util.misc import object_to_qualified_name, OrderedDict
 
 # 'ExamplePoint' is an example type which may come from Cate API or other required API.
 ExamplePoint = namedtuple('ExamplePoint', ['x', 'y'])

--- a/test/core/test_workflow.py
+++ b/test/core/test_workflow.py
@@ -6,7 +6,7 @@ from unittest import TestCase
 from cate.core.op import op_input, op_output, Operation
 from cate.core.workflow import OpStep, Workflow, WorkflowStep, NodePort, ExpressionStep, NoOpStep, SubProcessStep, ValueCache, \
     SourceRef, new_workflow_op
-from cate.util import UNDEFINED
+from cate.util.undefined import UNDEFINED
 from cate.util.misc import object_to_qualified_name
 from cate.util.opmetainf import OpMetaInfo
 

--- a/test/core/test_workspace.py
+++ b/test/core/test_workspace.py
@@ -9,7 +9,7 @@ import xarray as xr
 
 from cate.core.workflow import Workflow, OpStep
 from cate.core.workspace import Workspace, WorkspaceError, mk_op_arg, mk_op_args, mk_op_kwargs
-from cate.util import UNDEFINED
+from cate.util.undefined import UNDEFINED
 from cate.util.opmetainf import OpMetaInfo
 
 NETCDF_TEST_FILE_1 = os.path.join(os.path.dirname(__file__), '..', 'data', 'precip_and_temp.nc')

--- a/test/util/test_filter_fileset.py
+++ b/test/util/test_filter_fileset.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from cate.util import filter_fileset
+from cate.util.misc import filter_fileset
 
 
 class IncludeExcludeDataSourcesTest(TestCase):

--- a/test/util/web/test_jsonrpchandler.py
+++ b/test/util/web/test_jsonrpchandler.py
@@ -1,6 +1,6 @@
 import unittest
 
-from cate.util import Monitor
+from cate.util.monitor import Monitor
 from cate.util.web.jsonrpchandler import JsonRpcWebSocketHandler, set_debug_web_socket_rpc
 
 set_debug_web_socket_rpc(True)


### PR DESCRIPTION
This partly addresses #58, as `cate --version` and `cate -h` now perform much faster.

Performance improvement comes from two optimisations:

1. `cate.util` does not aggregate sub-packages anymore. We have to explicitly import now. This is because some sub-packages imports are slow, notably the new `cate.util.opimpl`.   
2. CLI commands in `cate.cli.main` now only import required modules when they are executed.   