### PR TITLE
86 jg animation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,8 @@
   `read_geo_data_frame`.
 * CLI now launches a lot faster, e.g. try now `cate -h`
   [#58](https://github.com/CCI-Tools/cate/issues/58)
+* Cate can now produce animated figures
+  [#86](https://github.com/CCI-Tools/cate/issues/86)
 
 ### Fixes
 
@@ -27,8 +29,10 @@
   [#466](https://github.com/CCI-Tools/cate/issues/466)
 * Region constraint'-option for AEROSOL dataset returns 'code 20' error
   [#462](https://github.com/CCI-Tools/cate/issues/462)
- * Address problems of a user working with Cloud and Aerosol
+* Address problems of a user working with Cloud and Aerosol
   [#478](https://github.com/CCI-Tools/cate/issues/478)
+* Most projections not working in plot operations
+  [#524](https://github.com/CCI-Tools/cate/issues/524)
 
 ## Version 1.0 (10.10.2017)
 

--- a/cate/core/types.py
+++ b/cate/core/types.py
@@ -165,6 +165,26 @@ class Arbitrary(Like[Any]):
         return str(value)
 
 
+class HTML(Like[str]):
+    """
+    Represents HTML string
+    """
+    TYPE = str
+
+    @classmethod
+    def convert(cls, value: str) -> str:
+        """
+        Return **value**
+        """
+        return value
+
+    @classmethod
+    def format(cls, value: str) -> str:
+        if value is None:
+            return ''
+        return value
+
+
 class Literal(Like[Any]):
     """
     Represents an arbitrary Python literal.

--- a/cate/ops/__init__.py
+++ b/cate/ops/__init__.py
@@ -54,7 +54,7 @@ from .correlation import pearson_correlation_scalar, pearson_correlation
 from .normalize import normalize, adjust_temporal_attrs, adjust_spatial_attrs
 from .io import open_dataset, save_dataset, read_object, write_object, read_text, write_text, read_json, write_json, \
     read_csv, read_geo_data_frame, read_netcdf, write_netcdf3, write_netcdf4
-from .plot import plot_map, plot, plot_dataframe
+from .plot import plot_map, plot, plot_data_frame
 from .animate import animate_map
 from .resampling import resample_2d, downsample_2d, upsample_2d
 from .subset import subset_spatial, subset_temporal, subset_temporal_index

--- a/cate/ops/__init__.py
+++ b/cate/ops/__init__.py
@@ -54,7 +54,8 @@ from .correlation import pearson_correlation_scalar, pearson_correlation
 from .normalize import normalize, adjust_temporal_attrs, adjust_spatial_attrs
 from .io import open_dataset, save_dataset, read_object, write_object, read_text, write_text, read_json, write_json, \
     read_csv, read_geo_data_frame, read_netcdf, write_netcdf3, write_netcdf4
-from .plot import plot_map, plot, animate_map
+from .plot import plot_map, plot, plot_dataframe
+from .animate import animate_map
 from .resampling import resample_2d, downsample_2d, upsample_2d
 from .subset import subset_spatial, subset_temporal, subset_temporal_index
 from .timeseries import tseries_point, tseries_mean
@@ -93,6 +94,8 @@ __all__ = [
     # .plot
     'plot_map',
     'plot',
+    'plot_dataframe',
+    # .animate
     'animate_map',
     # .io
     'open_dataset',
@@ -129,4 +132,8 @@ __all__ = [
     'oni',
     # .outliers
     'detect_outliers',
+    # .data_frame
+    'data_frame_min',
+    'data_frame_max',
+    'data_frame_query',
 ]

--- a/cate/ops/__init__.py
+++ b/cate/ops/__init__.py
@@ -54,7 +54,7 @@ from .correlation import pearson_correlation_scalar, pearson_correlation
 from .normalize import normalize, adjust_temporal_attrs, adjust_spatial_attrs
 from .io import open_dataset, save_dataset, read_object, write_object, read_text, write_text, read_json, write_json, \
     read_csv, read_geo_data_frame, read_netcdf, write_netcdf3, write_netcdf4
-from .plot import plot_map, plot, plot_data_frame
+from .plot import plot_map, plot, plot_contour, plot_scatter, plot_hist, plot_data_frame
 from .animate import animate_map
 from .resampling import resample_2d, downsample_2d, upsample_2d
 from .subset import subset_spatial, subset_temporal, subset_temporal_index
@@ -94,7 +94,10 @@ __all__ = [
     # .plot
     'plot_map',
     'plot',
-    'plot_dataframe',
+    'plot_data_frame',
+    'plot_contour',
+    'plot_scatter',
+    'plot_hist',
     # .animate
     'animate_map',
     # .io

--- a/cate/ops/__init__.py
+++ b/cate/ops/__init__.py
@@ -54,7 +54,7 @@ from .correlation import pearson_correlation_scalar, pearson_correlation
 from .normalize import normalize, adjust_temporal_attrs, adjust_spatial_attrs
 from .io import open_dataset, save_dataset, read_object, write_object, read_text, write_text, read_json, write_json, \
     read_csv, read_geo_data_frame, read_netcdf, write_netcdf3, write_netcdf4
-from .plot import plot_map, plot, plot_data_frame
+from .plot import plot_map, plot, animate_map
 from .resampling import resample_2d, downsample_2d, upsample_2d
 from .subset import subset_spatial, subset_temporal, subset_temporal_index
 from .timeseries import tseries_point, tseries_mean
@@ -93,7 +93,7 @@ __all__ = [
     # .plot
     'plot_map',
     'plot',
-    'plot_data_frame',
+    'animate_map',
     # .io
     'open_dataset',
     'save_dataset',

--- a/cate/ops/animate.py
+++ b/cate/ops/animate.py
@@ -149,7 +149,11 @@ def animate_map(ds: xr.Dataset,
             break
     else:
         var_name = VarName.convert(var)
-    var = ds[var_name]
+
+    try:
+        var = ds[var_name]
+    except KeyError:
+        raise ValueError('Provided variable name "{}" does not exist in the given dataset'.format(var_name))
 
     indexers = DictLike.convert(indexers) or {}
     properties = DictLike.convert(plot_properties) or {}

--- a/cate/ops/animate.py
+++ b/cate/ops/animate.py
@@ -44,7 +44,7 @@ If a file path is given, the plot is saved.
 Supported formats: html
 
 """
-
+import os
 import matplotlib
 
 has_qt5agg = False
@@ -212,6 +212,8 @@ def animate_map(ds: xr.Dataset,
 
         cmap_params = determine_cmap_params(data_min, data_max, **cmap_params)
         plot_kwargs = {**properties, **cmap_params}
+
+        # Plot the first frame to set-up the axes with the colorbar properly
         var_data.plot.contourf(ax=ax, transform=ccrs.PlateCarree(), subplot_kws={'projection': proj},
                                add_colorbar=True, **plot_kwargs)
         if title:
@@ -237,6 +239,15 @@ def animate_map(ds: xr.Dataset,
         anim = animation.FuncAnimation(figure, run, [i for i in var[animate_dim]],
                                        interval=25, blit=False, repeat=False)
         anim_html = anim.to_jshtml()
+
+        # Prevent the animation for running after it's finished
+        del anim
+
+        # Delete the rogue temp-file
+        try:
+            os.remove('None0000000.png')
+        except FileNotFoundError:
+            pass
 
         if file:
             with open(file, 'w') as outfile:

--- a/cate/ops/animate.py
+++ b/cate/ops/animate.py
@@ -66,7 +66,7 @@ import xarray as xr
 import numpy as np
 
 from cate.core.op import op, op_input
-from cate.core.types import VarName, DictLike, PolygonLike
+from cate.core.types import VarName, DictLike, PolygonLike, HTML
 from cate.util.monitor import Monitor
 
 from cate.ops.plot_helpers import (get_var_data,
@@ -101,7 +101,7 @@ def animate_map(ds: xr.Dataset,
                 cmap_params: DictLike.TYPE = None,
                 plot_properties: DictLike.TYPE = None,
                 file: str = None,
-                monitor: Monitor = Monitor.NONE) -> object:
+                monitor: Monitor = Monitor.NONE) -> HTML:
     """
     Create a geographic map animation for the variable given by dataset *ds* and variable name *var*.
 

--- a/cate/ops/animate.py
+++ b/cate/ops/animate.py
@@ -107,13 +107,13 @@ def animate_map(ds: xr.Dataset,
 
     Creates an animation of the given variable from the given dataset on a map with coastal lines.
     In case no variable name is given, the first encountered variable in the
-    dataset is plotted.
-    It is also possible to set extents of the plot. If no extents
-    are given, a global plot is created.
+    dataset is animated.
+    It is also possible to set extents of the animation. If no extents
+    are given, a global animation is created.
 
     The following file formats for saving the animation are supported: html
 
-    :param ds: the dataset containing the variable to plot
+    :param ds: the dataset containing the variable to animate
     :param var: the variable's name
     :param animate_dim: Dimension to animate, if none given defaults to time.
     :param global_cmap: If True, calculates colormap and colorbar configuration parameters from the
@@ -122,7 +122,7 @@ def animate_map(ds: xr.Dataset,
     :param indexers: Optional indexers into data array of *var*. The *indexers* is a dictionary
            or a comma-separated string of key-value pairs that maps the variable's dimension names
            to constant labels. e.g. "layer=4".
-    :param region: Region to plot
+    :param region: Region to animate
     :param projection: name of a global projection, see http://scitools.org.uk/cartopy/docs/v0.15/crs/projections.html
     :param central_lon: central longitude of the projection in degrees
     :param title: an optional title
@@ -135,7 +135,7 @@ def animate_map(ds: xr.Dataset,
            For full reference refer to
            https://matplotlib.org/api/lines_api.html and
            https://matplotlib.org/api/_as_gen/matplotlib.axes.Axes.contourf.html
-    :param file: path to a file in which to save the plot
+    :param file: path to a file in which to save the animation
     :param monitor: A progress monitor.
     :return: An animation in HTML format
     """

--- a/cate/ops/animate.py
+++ b/cate/ops/animate.py
@@ -1,0 +1,219 @@
+# The MIT License (MIT)
+# Copyright (c) 2016, 2017 by the ESA CCI Toolbox development team and contributors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do
+# so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""
+Description
+===========
+
+CLI/API data animation operations
+
+Components
+==========
+
+## animate_map
+
+Animates a geospatial data slice on a world map.
+
+General jupyter notebook usage:
+```python
+import cate.ops as ops
+from IPython.core.display import display, HTML
+dset = ops.open_dataset('local.dataset_name')
+display(HTML(ops.animate_map(cc, var='var_name')))
+```
+
+If a file path is given, the plot is saved.
+Supported formats: html
+
+"""
+
+import matplotlib
+
+has_qt5agg = False
+# noinspection PyBroadException
+try:
+    if not matplotlib.__version__.startswith('1.'):
+        matplotlib.use('Qt5Agg')
+        has_qt5agg = True
+except Exception:
+    pass
+if not has_qt5agg:
+    matplotlib.use('Qt4Agg')
+
+import matplotlib.animation as animation
+import matplotlib.pyplot as plt
+
+import cartopy.crs as ccrs
+import xarray as xr
+
+from cate.core.op import op, op_input
+from cate.core.types import VarName, DictLike, PolygonLike
+
+from cate.ops.plot_helpers import get_var_data
+from cate.ops.plot_helpers import check_bounding_box
+
+ANIMATION_FILE_FILTER = dict(name='Animation Outputs', extensions=['html', ])
+
+
+@op(tags=['plot'], res_pattern='animation_{index}')
+@op_input('ds')
+@op_input('var', value_set_source='ds', data_type=VarName)
+@op_input('indexers', data_type=DictLike)
+@op_input('region', data_type=PolygonLike)
+@op_input('projection', value_set=['PlateCarree', 'LambertCylindrical', 'Mercator', 'Miller',
+                                   'Mollweide', 'Orthographic', 'Robinson', 'Sinusoidal',
+                                   'NorthPolarStereo', 'SouthPolarStereo'])
+@op_input('central_lon', units='degrees', value_range=[-180, 180])
+@op_input('title')
+@op_input('properties', data_type=DictLike)
+@op_input('file', file_open_mode='w', file_filters=[ANIMATION_FILE_FILTER])
+def animate_map(ds: xr.Dataset,
+                var: VarName.TYPE = None,
+                indexers: DictLike.TYPE = None,
+                region: PolygonLike.TYPE = None,
+                projection: str = 'PlateCarree',
+                central_lon: float = 0.0,
+                title: str = None,
+                properties: DictLike.TYPE = None,
+                file: str = None) -> object:
+    """
+    Create a geographic map animation for the variable given by dataset *ds* and variable name *var*.
+
+    Creates an animation of the given variable from the given dataset on a map with coastal lines.
+    In case no variable name is given, the first encountered variable in the
+    dataset is plotted.
+    It is also possible to set extents of the plot. If no extents
+    are given, a global plot is created.
+
+    The animation can either be shown using pyplot functionality, or saved,
+    if a path is given. The following file formats for saving the animation
+    are supported: html
+
+    :param ds: the dataset containing the variable to plot
+    :param var: the variable's name
+    :param indexers: Optional indexers into data array of *var*. The *indexers* is a dictionary
+           or a comma-separated string of key-value pairs that maps the variable's dimension names
+           to constant labels. e.g. "layer=4".
+    :param region: Region to plot
+    :param projection: name of a global projection, see http://scitools.org.uk/cartopy/docs/v0.15/crs/projections.html
+    :param central_lon: central longitude of the projection in degrees
+    :param title: an optional title
+    :param properties: optional plot properties for Python matplotlib,
+           e.g. "bins=512, range=(-1.5, +1.5)"
+           For full reference refer to
+           https://matplotlib.org/api/lines_api.html and
+           https://matplotlib.org/api/_as_gen/matplotlib.axes.Axes.contourf.html
+    :param file: path to a file in which to save the plot
+    :return: a matplotlib figure object or None if in IPython mode
+    """
+    if not isinstance(ds, xr.Dataset):
+        raise NotImplementedError('Only gridded datasets are currently supported')
+
+    var_name = None
+    if not var:
+        for key in ds.data_vars.keys():
+            var_name = key
+            break
+    else:
+        var_name = VarName.convert(var)
+    var = ds[var_name]
+
+    indexers = DictLike.convert(indexers) or {}
+    properties = DictLike.convert(properties) or {}
+
+    extents = None
+    region = PolygonLike.convert(region)
+    if region:
+        lon_min, lat_min, lon_max, lat_max = region.bounds
+        if not check_bounding_box(lat_min, lat_max, lon_min, lon_max):
+            raise ValueError('Provided plot extents do not form a valid bounding box '
+                             'within [-180.0,+180.0,-90.0,+90.0]')
+        extents = [lon_min, lon_max, lat_min, lat_max]
+
+    # See http://scitools.org.uk/cartopy/docs/v0.15/crs/projections.html#
+    if projection == 'PlateCarree':
+        proj = ccrs.PlateCarree(central_longitude=central_lon)
+    elif projection == 'LambertCylindrical':
+        proj = ccrs.LambertCylindrical(central_longitude=central_lon)
+    elif projection == 'Mercator':
+        proj = ccrs.Mercator(central_longitude=central_lon)
+    elif projection == 'Miller':
+        proj = ccrs.Miller(central_longitude=central_lon)
+    elif projection == 'Mollweide':
+        proj = ccrs.Mollweide(central_longitude=central_lon)
+    elif projection == 'Orthographic':
+        proj = ccrs.Orthographic(central_longitude=central_lon)
+    elif projection == 'Robinson':
+        proj = ccrs.Robinson(central_longitude=central_lon)
+    elif projection == 'Sinusoidal':
+        proj = ccrs.Sinusoidal(central_longitude=central_lon)
+    elif projection == 'NorthPolarStereo':
+        proj = ccrs.NorthPolarStereo(central_longitude=central_lon)
+    elif projection == 'SouthPolarStereo':
+        proj = ccrs.SouthPolarStereo(central_longitude=central_lon)
+    else:
+        raise ValueError('illegal projection: "%s"' % projection)
+
+    figure = plt.figure(figsize=(8, 4))
+    ax = plt.axes(projection=proj)
+    if extents:
+        ax.set_extent(extents)
+    else:
+        ax.set_global()
+
+    ax.coastlines()
+    var_data = get_var_data(var, indexers, time=var.time[0], remaining_dims=('lon', 'lat'))
+    var_data.plot.contourf(ax=ax, transform=proj, add_colorbar=True, **properties)
+
+    if title:
+        ax.set_title(title)
+
+    figure.tight_layout()
+
+    def run(time):
+        # Add monitor here.
+        # Make it cancellable.
+        # Add the possibility to calculate 'true' vmin and vmax.
+        # Make sure we can see the animation in a Jupyter notebook
+        # display(HTML(ops.animate_map(cc, var='cfc_low')))
+        ax.clear()
+        if title:
+            ax.set_title(title)
+        if extents:
+            ax.set_extent(extents)
+        else:
+            ax.set_global()
+        ax.coastlines()
+        var_data = get_var_data(var, indexers, time=time,
+                                remaining_dims=('lon', 'lat'))
+        var_data.plot.contourf(ax=ax, transform=proj, add_colorbar=False, **properties)
+        return ax
+
+    anim = animation.FuncAnimation(figure, run, [t for t in var.time],
+                                   interval=25, blit=False)
+
+    anim_html = anim.to_jshtml()
+
+    if file:
+        with open(file, 'w') as outfile:
+            outfile.write(anim_html)
+
+    return anim_html

--- a/cate/ops/animate.py
+++ b/cate/ops/animate.py
@@ -92,7 +92,7 @@ ANIMATION_FILE_FILTER = dict(name='Animation Outputs', extensions=['html', ])
 def animate_map(ds: xr.Dataset,
                 var: VarName.TYPE = None,
                 animate_dim: str = 'time',
-                global_cmap: bool = False,
+                true_range: bool = False,
                 indexers: DictLike.TYPE = None,
                 region: PolygonLike.TYPE = None,
                 projection: str = 'PlateCarree',
@@ -116,7 +116,7 @@ def animate_map(ds: xr.Dataset,
     :param ds: the dataset containing the variable to animate
     :param var: the variable's name
     :param animate_dim: Dimension to animate, if none given defaults to time.
-    :param global_cmap: If True, calculates colormap and colorbar configuration parameters from the
+    :param true_range: If True, calculates colormap and colorbar configuration parameters from the
     whole dataset. Can potentially take a lot of time. Defaults to False, in which case the colormap
     is calculated from the first frame.
     :param indexers: Optional indexers into data array of *var*. The *indexers* is a dictionary
@@ -209,7 +209,7 @@ def animate_map(ds: xr.Dataset,
     var_data = get_var_data(var, indexers, remaining_dims=('lon', 'lat'))
 
     with monitor.starting("animate", len(var[animate_dim]) + 3):
-        if global_cmap:
+        if true_range:
             data_min, data_max = _get_min_max(var, monitor=monitor)
         else:
             data_min, data_max = _get_min_max(var_data, monitor=monitor)

--- a/cate/ops/animate.py
+++ b/cate/ops/animate.py
@@ -212,16 +212,15 @@ def animate_map(ds: xr.Dataset,
 
         cmap_params = determine_cmap_params(data_min, data_max, **cmap_params)
         plot_kwargs = {**properties, **cmap_params}
-        var_data.plot.contourf(ax=ax, transform=proj, add_colorbar=True, **plot_kwargs)
-        monitor.progress(1)
+        var_data.plot.contourf(ax=ax, transform=ccrs.PlateCarree(), subplot_kws={'projection': proj},
+                               add_colorbar=True, **plot_kwargs)
         if title:
             ax.set_title(title)
         figure.tight_layout()
+        monitor.progress(1)
 
         def run(value):
             ax.clear()
-            if title:
-                ax.set_title(title)
             if extents:
                 ax.set_extent(extents)
             else:
@@ -229,7 +228,10 @@ def animate_map(ds: xr.Dataset,
             ax.coastlines()
             indexers[animate_dim] = value
             var_data = get_var_data(var, indexers, remaining_dims=('lon', 'lat'))
-            var_data.plot.contourf(ax=ax, transform=proj, add_colorbar=False, **plot_kwargs)
+            var_data.plot.contourf(ax=ax, transform=ccrs.PlateCarree(), subplot_kws={'projection': proj},
+                                   add_colorbar=False, **plot_kwargs)
+            if title:
+                ax.set_title(title)
             monitor.progress(1)
             return ax
         anim = animation.FuncAnimation(figure, run, [i for i in var[animate_dim]],

--- a/cate/ops/animate.py
+++ b/cate/ops/animate.py
@@ -254,10 +254,8 @@ def _get_min_max(data, monitor=None):
     with monitor.child(1).observing("find minimum"):
         data_min = data.min()
     if np.isnan(data_min):
-        # Handle all-NaN dataset gracefully
-        data_min = 0
-        data_max = 0
-        monitor.progress(1)
+        # Handle all-NaN dataset
+        raise ValueError('Can not create an animation of a dataset containing only NaN values.')
     else:
         with monitor.child(1).observing("find maximum"):
             data_max = data.max()

--- a/cate/ops/plot.py
+++ b/cate/ops/plot.py
@@ -500,42 +500,6 @@ def plot_hist(ds: xr.Dataset,
     return figure if not in_notebook() else None
 
 
-# TODO (forman): remove the 'plot_data_frame' operation. It is too specific.
-# Instead, make other 'plot_' ops accept xarray and pandas objects.
-
-@op(tags=['plot'], res_pattern='plot_{index}')
-@op_input('plot_type', value_set=['line', 'bar', 'barh', 'hist', 'box', 'kde',
-                                  'area', 'pie', 'scatter', 'hexbin'])
-@op_input('file', file_open_mode='w', file_filters=[PLOT_FILE_FILTER])
-def plot_data_frame(df: pd.DataFrame,
-                    plot_type: str = 'line',
-                    file: str = None,
-                    **kwargs) -> Figure:
-    """
-    Plot a data frame.
-
-    This is a wrapper of pandas.DataFrame.plot() function.
-
-    For further documentation please see
-    http://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.plot.html
-
-    :param df: A pandas dataframe to plot
-    :param plot_type: Plot type
-    :param file: path to a file in which to save the plot
-    :param kwargs: Keyword arguments to pass to the underlying
-                   pandas.DataFrame.plot function
-    """
-    if not isinstance(df, pd.DataFrame):
-        raise NotImplementedError('"df" must be of type "pandas.DataFrame"')
-
-    ax = df.plot(kind=plot_type, figsize=(8, 4), **kwargs)
-    figure = ax.get_figure()
-    if file:
-        figure.savefig(file)
-
-    return figure if not in_notebook() else None
-
-
 def _check_bounding_box(lat_min: float,
                         lat_max: float,
                         lon_min: float,

--- a/cate/ops/plot.py
+++ b/cate/ops/plot.py
@@ -201,7 +201,10 @@ def plot_map(ds: xr.Dataset,
 
     ax.coastlines()
     var_data = get_var_data(var, indexers, time=time, remaining_dims=('lon', 'lat'))
-    var_data.plot.contourf(ax=ax, transform=proj, **properties)
+
+    # transform keyword is for the coordinate our data is in, which in case of a
+    # 'normal' lat/lon dataset is PlateCarree.
+    var_data.plot.contourf(ax=ax, transform=ccrs.PlateCarree(), subplot_kws={'projection': proj}, **properties)
 
     if title:
         ax.set_title(title)

--- a/cate/ops/plot.py
+++ b/cate/ops/plot.py
@@ -280,7 +280,7 @@ def plot_contour(ds: xr.Dataset,
 @op_input('title')
 @op_input('properties', data_type=DictLike)
 @op_input('file', file_open_mode='w', file_filters=[PLOT_FILE_FILTER])
-def plot(ds: xr.Dataset,
+def plot(ds: DatasetLike.TYPE,
          var: VarName.TYPE,
          indexers: DictLike.TYPE = None,
          title: str = None,

--- a/cate/ops/plot.py
+++ b/cate/ops/plot.py
@@ -85,7 +85,6 @@ PLOT_FILE_EXTENSIONS = ['eps', 'jpeg', 'jpg', 'pdf', 'pgf',
                         'png', 'ps', 'raw', 'rgba', 'svg',
                         'svgz', 'tif', 'tiff']
 PLOT_FILE_FILTER = dict(name='Plot Outputs', extensions=PLOT_FILE_EXTENSIONS)
-ANIMATION_FILE_FILTER = dict(name='Animation Outputs', extensions=['html', ])
 
 
 @op(tags=['plot'], res_pattern='plot_{index}')

--- a/cate/ops/plot_helpers.py
+++ b/cate/ops/plot_helpers.py
@@ -85,3 +85,180 @@ def get_var_data(var, indexers: dict, time=None, remaining_dims=None):
         var = var.isel(**isel_indexers)
 
     return var
+
+
+# determine_cmap_params is adapted from Xarray through Seaborn:
+# https://github.com/pydata/xarray/blob/master/xarray/plot/utils.py#L151
+# https://github.com/mwaskom/seaborn/blob/v0.6/seaborn/matrix.py#L158
+# Used under the terms of Seaborn's license:
+# https://github.com/mwaskom/seaborn/blob/v0.8.1/LICENSE
+#
+# _determine_extend, _build_discrete_cmap, _color_palette, _is_scalar are
+# adapted from Xarray and used under Xarray license:
+# https://github.com/pydata/xarray/blob/v0.10.0/LICENSE
+
+ROBUST_QUANTILE = 0.02
+
+
+def determine_cmap_params(data_min, data_max, vmin=None, vmax=None, cmap=None,
+                          center=None, robust=False, extend=None,
+                          levels=None, filled=True, norm=None):
+    """
+    Use some heuristics to set good defaults for colorbar and range.
+
+    :param plot_data: Data to use to determine colormap parameters
+    :return: A dictionary containing calculated parameters
+    """
+    import matplotlib as mpl
+    import numpy as np
+
+    # Setting center=False prevents a divergent cmap
+    possibly_divergent = center is not False
+
+    # Set center to 0 so math below makes sense but remember its state
+    center_is_none = False
+    if center is None:
+        center = 0
+        center_is_none = True
+
+    # Setting both vmin and vmax prevents a divergent cmap
+    if (vmin is not None) and (vmax is not None):
+        possibly_divergent = False
+
+    # Setting vmin or vmax implies linspaced levels
+    user_minmax = (vmin is not None) or (vmax is not None)
+
+    # vlim might be computed below
+    vlim = None
+
+    if vmin is None:
+        vmin = data_min
+    elif possibly_divergent:
+        vlim = abs(vmin - center)
+
+    if vmax is None:
+        vmax = data_max
+    elif possibly_divergent:
+        vlim = abs(vmax - center)
+
+    if possibly_divergent:
+        # kwargs not specific about divergent or not: infer defaults from data
+        divergent = ((vmin < 0) and (vmax > 0)) or not center_is_none
+    else:
+        divergent = False
+
+    # A divergent map should be symmetric around the center value
+    if divergent:
+        if vlim is None:
+            vlim = max(abs(vmin - center), abs(vmax - center))
+        vmin, vmax = -vlim, vlim
+
+    # Now add in the centering value and set the limits
+    vmin += center
+    vmax += center
+
+    # Choose default colormaps if not provided
+    if cmap is None:
+        if divergent:
+            cmap = "RdBu_r"
+        else:
+            cmap = "viridis"
+
+    # Handle discrete levels
+    if levels is not None:
+        if _is_scalar(levels):
+            if user_minmax or levels == 1:
+                levels = np.linspace(vmin, vmax, levels)
+            else:
+                # N in MaxNLocator refers to bins, not ticks
+                ticker = mpl.ticker.MaxNLocator(levels - 1)
+                levels = ticker.tick_values(vmin, vmax)
+        vmin, vmax = levels[0], levels[-1]
+
+    if extend is None:
+        extend = _determine_extend(data_min, data_max, vmin, vmax)
+
+    if levels is not None:
+        cmap, norm = _build_discrete_cmap(cmap, levels, extend, filled)
+
+    return dict(vmin=vmin, vmax=vmax, cmap=cmap, extend=extend,
+                levels=levels, norm=norm)
+
+
+def _determine_extend(data_min, data_max, vmin, vmax):
+    extend_min = data_min < vmin
+    extend_max = data_max > vmax
+    if extend_min and extend_max:
+        extend = 'both'
+    elif extend_min:
+        extend = 'min'
+    elif extend_max:
+        extend = 'max'
+    else:
+        extend = 'neither'
+    return extend
+
+
+def _build_discrete_cmap(cmap, levels, extend, filled):
+    """Build a discrete colormap and normalization of the data."""
+    import matplotlib as mpl
+
+    if not filled:
+        # non-filled contour plots
+        extend = 'max'
+
+    if extend == 'both':
+        ext_n = 2
+    elif extend in ['min', 'max']:
+        ext_n = 1
+    else:
+        ext_n = 0
+
+    n_colors = len(levels) + ext_n - 1
+    pal = _color_palette(cmap, n_colors)
+
+    new_cmap, cnorm = mpl.colors.from_levels_and_colors(
+        levels, pal, extend=extend)
+    # copy the old cmap name, for easier testing
+    new_cmap.name = getattr(cmap, 'name', cmap)
+
+    return new_cmap, cnorm
+
+
+def _color_palette(cmap, n_colors):
+    import matplotlib.pyplot as plt
+    from matplotlib.colors import ListedColormap
+    import numpy as np
+
+    colors_i = np.linspace(0, 1., n_colors)
+    if isinstance(cmap, (list, tuple)):
+        # we have a list of colors
+        cmap = ListedColormap(cmap, N=n_colors)
+        pal = cmap(colors_i)
+    elif isinstance(cmap, str):
+        # we have some sort of named palette
+        try:
+            # is this a matplotlib cmap?
+            cmap = plt.get_cmap(cmap)
+        except ValueError:
+            # or maybe we just got a single color as a string
+            cmap = ListedColormap([cmap], N=n_colors)
+        pal = cmap(colors_i)
+    else:
+        # cmap better be a LinearSegmentedColormap (e.g. viridis)
+        pal = cmap(colors_i)
+
+    return pal
+
+
+def _is_scalar(value):
+    """Whether to treat a value as a scalar.
+    Any non-iterable, string, or 0-D array
+    """
+    import dask
+    from collections import Iterable
+
+    return (
+        getattr(value, 'ndim', None) == 0 or
+        isinstance(value, (str, bytes)) or not
+        isinstance(value, (Iterable, ) + dask.array.Array))

--- a/cate/ops/plot_helpers.py
+++ b/cate/ops/plot_helpers.py
@@ -28,30 +28,6 @@ Helpers for data visualization operations (plot and animate).
 Components
 ==========
 
-## plot_map
-
-Plots a geospatial data slice on a world map. General python prompt usage:
-
-```python
-import matplotlib.pyplot as plt
-from cate.ops.plot import plot_map
-
-plot_map(dset)
-plt.show()
-```
-
-General jupyter notebook usage:
-```python
-import matplotlib.pyplot as plt
-from cate.ops.plot import plot_map
-
-%matplotlib inline
-plot_map(dset)
-```
-If a file path is given, the plot is saved.
-Supported formats: eps, jpeg, jpg, pdf, pgf, png, ps, raw, rgba, svg,
-svgz, tif, tiff
-
 """
 
 

--- a/cate/ops/plot_helpers.py
+++ b/cate/ops/plot_helpers.py
@@ -255,10 +255,9 @@ def _is_scalar(value):
     """Whether to treat a value as a scalar.
     Any non-iterable, string, or 0-D array
     """
-    import dask
     from collections import Iterable
 
     return (
         getattr(value, 'ndim', None) == 0 or
         isinstance(value, (str, bytes)) or not
-        isinstance(value, (Iterable, ) + dask.array.Array))
+        isinstance(value, (Iterable, )))

--- a/cate/ops/plot_helpers.py
+++ b/cate/ops/plot_helpers.py
@@ -1,0 +1,111 @@
+# The MIT License (MIT)
+# Copyright (c) 2016, 2017 by the ESA CCI Toolbox development team and contributors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do
+# so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""
+Description
+===========
+
+Helpers for data visualization operations (plot and animate).
+
+Components
+==========
+
+## plot_map
+
+Plots a geospatial data slice on a world map. General python prompt usage:
+
+```python
+import matplotlib.pyplot as plt
+from cate.ops.plot import plot_map
+
+plot_map(dset)
+plt.show()
+```
+
+General jupyter notebook usage:
+```python
+import matplotlib.pyplot as plt
+from cate.ops.plot import plot_map
+
+%matplotlib inline
+plot_map(dset)
+```
+If a file path is given, the plot is saved.
+Supported formats: eps, jpeg, jpg, pdf, pgf, png, ps, raw, rgba, svg,
+svgz, tif, tiff
+
+"""
+
+
+def check_bounding_box(lat_min: float,
+                       lat_max: float,
+                       lon_min: float,
+                       lon_max: float) -> bool:
+    """
+    Check if the provided [lat_min, lat_max, lon_min, lon_max] extents
+    are sane.
+    """
+    if lat_min >= lat_max:
+        return False
+
+    if lon_min >= lon_max:
+        return False
+
+    if lat_min < -90.0:
+        return False
+
+    if lat_max > 90.0:
+        return False
+
+    if lon_min < -180.0:
+        return False
+
+    if lon_max > 180.0:
+        return False
+
+    return True
+
+
+def in_notebook():
+    """
+    Return ``True`` if the module is running in IPython kernel,
+    ``False`` if in IPython shell or other Python shell.
+    """
+    import sys
+    ipykernel_in_sys_modules = 'ipykernel' in sys.modules
+    # print('###########################################', ipykernel_in_sys_modules)
+    return ipykernel_in_sys_modules
+
+
+def get_var_data(var, indexers: dict, time=None, remaining_dims=None):
+    """Select an arbitrary piece of an xarray dataset by using indexers."""
+    if time is not None:
+        indexers = dict(indexers) if indexers else dict()
+        indexers['time'] = time
+
+    if indexers:
+        var = var.sel(method='nearest', **indexers)
+
+    if remaining_dims:
+        isel_indexers = {dim_name: 0 for dim_name in var.dims if dim_name not in remaining_dims}
+        var = var.isel(**isel_indexers)
+
+    return var

--- a/cate/util/im/image.py
+++ b/cate/util/im/image.py
@@ -23,7 +23,7 @@ import io
 import time
 import uuid
 from abc import ABCMeta, abstractmethod
-from typing import Tuple, Sequence, Union, Any, Callable, Optional, List
+from typing import Tuple, Sequence, Union, Any, Callable, Optional
 
 import matplotlib.cm as cm
 import numpy as np
@@ -392,10 +392,10 @@ class TransformArrayImage(DecoratorImage):
                         return x
                 # and we have a valid min or max, return a masked tile
                 if valid_min is not None:
-                    #valid_min = convert(valid_min)
+                    # valid_min = convert(valid_min)
                     tile = np.ma.masked_less(tile, valid_min)
                 if valid_max is not None:
-                    #valid_max = convert(valid_max)
+                    # valid_max = convert(valid_max)
                     tile = np.ma.masked_greater(tile, valid_max)
             elif np.issubdtype(tile.dtype, float) or np.issubdtype(tile.dtype, complex):
                 # and it is of float type, return a masked tile with a mask from invalids, i.e. NaN, -Inf, +Inf

--- a/cate/webapi/rest.py
+++ b/cate/webapi/rest.py
@@ -139,7 +139,6 @@ class ResVarTileHandler(WorkspaceResourceHandler):
                     if valid_min is not None and valid_max is not None:
                         valid_range = [valid_min, valid_max]
 
-
                 # Make sure we work with 2D image arrays only
                 if variable.ndim == 2:
                     array = variable

--- a/notebooks/cate-uc19.ipynb
+++ b/notebooks/cate-uc19.ipynb
@@ -1,0 +1,138 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Use Case 19\n",
+    "==========\n",
+    "\n",
+    "Problem Definition:\n",
+    "-------------------\n",
+    "\n",
+    "A climate scientist wishes to analyse potential correlations between *Ozone* and *Cloud* ECVs.\n",
+    "\n",
+    "Required Toolbox Features:\n",
+    "--------------------------\n",
+    "\n",
+    "* Access to and ingestion of ESA CCI GHG data\n",
+    "* Selection of required products/variables\n",
+    "* Temporal and spatial subsetting\n",
+    "* Generation of maps/animations depicting the evolution of GHG emissions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Ingest data and create the dataset\n",
+    "-------------------------------"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import cate.ops as ops\n",
+    "from cate.core.ds import DATA_STORE_REGISTRY\n",
+    "from cate.util.monitor import ConsoleMonitor\n",
+    "from IPython.core.display import display, HTML\n",
+    "\n",
+    "monitor = ConsoleMonitor()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# As CCI GHG L3 level data is not found in the esa cci odp remote repository, we'll look at ozone\n",
+    "data_store = DATA_STORE_REGISTRY.get_data_store('esa_cci_odp')\n",
+    "oz_remote_sources = data_store.query('esacci.OZONE.mon.L3.NP.multi-sensor.multi-platform.MERGED.fv0002.r1')\n",
+    "oz_remote_sources"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# To reduce bandwith select the region of interest, time range and variables right away\n",
+    "europe = 'POLYGON((-12.05078125 73.54664369613808,33.65234375 73.54664369613808,33.65234375 35.65604583948963,-12.05078125 35.65604583948963,-12.05078125 73.54664369613808))'\n",
+    "oz_remote_sources[0].make_local(local_name='ozone-europe.mon.2007.2008',\n",
+    "                                time_range='2007-01-01, 2008-12-31',\n",
+    "                                var_names='O3_du_tot, O3_ndens',\n",
+    "                                region=europe,\n",
+    "                                monitor=monitor)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "oz = ops.open_dataset('local.ozone-europe.mon.2007.2008')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "oz"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "display(HTML(ops.animate_map(oz, var='O3_du_tot', region=europe, global_cmap=True, monitor=monitor)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Let's look at ozone density at different air pressures in April, 2017\n",
+    "display(HTML(ops.animate_map(oz,\n",
+    "                             var='O3_ndens',\n",
+    "                             monitor=monitor,\n",
+    "                             animate_dim='air_pressure',\n",
+    "                             region=europe,\n",
+    "                             global_cmap=True,\n",
+    "                             indexers={'time':'2007-04-01'})))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/scripts/uc19.bat
+++ b/scripts/uc19.bat
@@ -1,0 +1,32 @@
+@echo off
+
+rem Download Ozone data. Select variables, region and time right away to save bandwith
+cate ds copy esacci.OZONE.mon.L3.NP.multi-sensor.multi-platform.MERGED.fv0002.r1 --name "ozone-europe.mon.2007.2008" --time 2007-01-01,2008-12-31 --vars "O3_du_tot, O3_ndens" --region "POLYGON((-12.05078125 73.54664369613808,33.65234375 73.54664369613808,33.65234375 35.65604583948963,-12.05078125 35.65604583948963,-12.05078125 73.54664369613808))"
+
+rmdir /S /Q uc19
+mkdir uc19
+cd uc19
+
+rem Start interactive session by initialising an empty workspace
+rem This will write a hidden directory .\.cate-workspace
+cate ws init
+
+rem Open the Ozone dataset and assign it to resource named "ozone"
+cate res open ozone local.ozone-europe.mon.2007.2008
+
+rem Create and save an animation over time for O3_du_tot
+cate res set anim1 animate_map ds=@ozone var="O3_du_tot" file="ozone-europe.html" global_cmap=True region="POLYGON((-12.05078125 73.54664369613808,33.65234375 73.54664369613808,33.65234375 35.65604583948963,-12.05078125 35.65604583948963,-12.05078125 73.54664369613808))"
+
+rem Create and save an animation over air_pressure for April 2007
+cate res set anim2 animate_map ds=@ozone var="O3_ndens" file="ozone-europe-pressure.html" animate_dim="air_pressure" indexers="{'time':'2007-04-01'}" global_cmap=True region="POLYGON((-12.05078125 73.54664369613808,33.65234375 73.54664369613808,33.65234375 35.65604583948963,-12.05078125 35.65604583948963,-12.05078125 73.54664369613808))"
+
+rem @Norman, tried 'cate run animate_map ds=@ozone ...', but wouldn't work, complained about unresolved references ds=ozone
+
+rem Save the workspace
+cate ws save
+rem Close the workspace
+cate ws close
+rem Exit interactive session. Don't ask, answer is always "yes".
+cate ws exit --yes
+
+cd ..

--- a/scripts/uc19.sh
+++ b/scripts/uc19.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# Download Ozone data. Select variables, region and time right away to save bandwith
+cate ds copy esacci.OZONE.mon.L3.NP.multi-sensor.multi-platform.MERGED.fv0002.r1 --name "ozone-europe.mon.2007.2008" --time 2007-01-01,2008-12-31 --vars "O3_du_tot, O3_ndens" --region "POLYGON((-12.05078125 73.54664369613808,33.65234375 73.54664369613808,33.65234375 35.65604583948963,-12.05078125 35.65604583948963,-12.05078125 73.54664369613808))"
+
+rm -rf uc19/
+mkdir uc19
+cd uc19
+
+# Start interactive session by initialising an empty workspace
+# This will write a hidden directory .\.cate-workspace
+cate ws init
+
+# Open the Ozone dataset and assign it to resource named "ozone"
+cate res open ozone local.ozone-europe.mon.2007.2008
+
+# Create and save an animation over time for O3_du_tot
+cate res set anim1 animate_map ds=@ozone var="O3_du_tot" file="ozone-europe.html" global_cmap=True region="POLYGON((-12.05078125 73.54664369613808,33.65234375 73.54664369613808,33.65234375 35.65604583948963,-12.05078125 35.65604583948963,-12.05078125 73.54664369613808))"
+
+# Create and save an animation over air_pressure for April 2007
+cate res set anim2 animate_map ds=@ozone var="O3_ndens" file="ozone-europe-pressure.html" animate_dim="air_pressure" indexers="{'time':'2007-04-01'}" global_cmap=True region="POLYGON((-12.05078125 73.54664369613808,33.65234375 73.54664369613808,33.65234375 35.65604583948963,-12.05078125 35.65604583948963,-12.05078125 73.54664369613808))"
+
+# @Norman, tried 'cate run animate_map ds=@ozone ...', but wouldn't work, complained about unresolved references ds=ozone
+
+# Save the workspace
+cate ws save
+# Close the workspace
+cate ws close
+# Exit interactive session. Don't ask, answer is always "yes".
+cate ws exit --yes
+
+cd ..

--- a/test/cli/test_main.py
+++ b/test/cli/test_main.py
@@ -290,7 +290,7 @@ class OperationCommandTest(CliTestCase):
         self.assert_main(['op', 'list', '--internal'], expected_stdout=['2 operations found'])
         self.assert_main(['op', 'list', '--tag', 'input'], expected_stdout=['7 operations found'])
         self.assert_main(['op', 'list', '--tag', 'output'], expected_stdout=['6 operations found'])
-        self.assert_main(['op', 'list', '--deprecated'], expected_stdout=['No operations found'])
+        self.assert_main(['op', 'list', '--deprecated'], expected_stdout=['One operation found'])
 
 
 @unittest.skip(reason='Hardcoded values from remote service, contains outdated assumptions')

--- a/test/ops/test_animate.py
+++ b/test/ops/test_animate.py
@@ -1,0 +1,142 @@
+"""
+Tests for animation operations
+"""
+import itertools
+import os
+import sys
+import shutil
+import tempfile
+from contextlib import contextmanager
+from unittest import TestCase
+import unittest
+
+import xarray as xr
+import numpy as np
+import pandas as pd
+
+from cate.ops.animate import animate_map
+
+_counter = itertools.count()
+ON_WIN = sys.platform == 'win32'
+
+
+@contextmanager
+def create_tmp_file(name, ext):
+    """
+    Create a temporary filename for testing
+    """
+    tmp_dir = tempfile.mkdtemp()
+    path = os.path.join(tmp_dir, '{}{}.{}'.format(name,
+                                                  next(_counter),
+                                                  ext))
+    try:
+        yield path
+    finally:
+        try:
+            shutil.rmtree(tmp_dir)
+        except OSError:
+            if not ON_WIN:
+                raise
+
+
+@unittest.skipIf(condition=os.environ.get('CATE_DISABLE_PLOT_TESTS', None),
+                 reason="skipped if CATE_DISABLE_PLOT_TESTS=1")
+class TestAnimateMap(TestCase):
+    """
+    Test animate_map() operation
+    """
+
+    def test_animate_map(self):
+        # Test the nominal functionality. This doesn't check that the animation is what is expected,
+        # rather, it simply tests if it seems to have been created
+        dataset = xr.Dataset({
+            'first': (['lat', 'lon', 'time'], np.random.rand(5, 10, 2)),
+            'second': (['lat', 'lon', 'time'], np.random.rand(5, 10, 2)),
+            'lat': np.linspace(-89.5, 89.5, 5),
+            'lon': np.linspace(-179.5, 179.5, 10),
+            'time': pd.date_range('2000-01-01', periods=2)})
+
+        with create_tmp_file('remove_me', 'html') as tmp_file:
+            animate_map(dataset, file=tmp_file)
+            self.assertTrue(os.path.isfile(tmp_file))
+
+        # Test if extents can be used
+        with create_tmp_file('remove_me', 'html') as tmp_file:
+            animate_map(dataset,
+                        var='second',
+                        region='-40.0, -20.0, 50.0, 60.0',
+                        file=tmp_file)
+            self.assertTrue(os.path.isfile(tmp_file))
+
+        # Test setting a Title
+        with create_tmp_file('remove_me', 'html') as tmp_file:
+            animate_map(dataset,
+                        var='second',
+                        title='Title',
+                        file=tmp_file)
+            self.assertTrue(os.path.isfile(tmp_file))
+
+        # Test using a global color map
+        with create_tmp_file('remove_me', 'html') as tmp_file:
+            animate_map(dataset,
+                        var='second',
+                        global_cmap=True,
+                        file=tmp_file)
+            self.assertTrue(os.path.isfile(tmp_file))
+
+    def test_plot_map_exceptions(self):
+        # Test if the corner cases are detected without creating a plot for it.
+
+        # Test value error is raised when passing an unexpected dataset type
+        with create_tmp_file('remove_me', 'html') as tmp_file:
+            with self.assertRaises(ValueError) as cm:
+                animate_map([1, 2, 4], file=tmp_file)
+            self.assertEqual(str(cm.exception),
+                             "input 'ds' for operation 'cate.ops.animate.animate_map' "
+                             "must be of type 'Dataset', but got type 'list'")
+            self.assertFalse(os.path.isfile(tmp_file))
+
+        # Test the extensions bound checking
+        dataset = xr.Dataset({
+            'first': (['lat', 'lon', 'time'], np.random.rand(2, 4, 1)),
+            'lat': np.linspace(-89.5, 89.5, 2),
+            'lon': np.linspace(-179.5, 179.5, 4)})
+
+        with self.assertRaises(ValueError):
+            region = '-40.0, -95.0, 50.0, 60.0',
+            animate_map(dataset, region=region)
+
+        with self.assertRaises(ValueError):
+            region = '-40.0, -20.0, 50.0, 95.0',
+            animate_map(dataset, region=region)
+
+        with self.assertRaises(ValueError):
+            region = '-181.0, -20.0, 50.0, 60.0',
+            animate_map(dataset, region=region)
+
+        with self.assertRaises(ValueError):
+            region = '-40.0, -20.0, 181.0, 60.0',
+            animate_map(dataset, region=region)
+
+        with self.assertRaises(ValueError):
+            region = '-40.0, -20.0, 50.0, -25.0',
+            animate_map(dataset, region=region)
+
+        with self.assertRaises(ValueError):
+            region = '-20.0, -20.0, -25.0, 60.0',
+            animate_map(dataset, region=region)
+
+        # Test all-nan dataset
+        dataset = xr.Dataset({
+            'first': (['lat', 'lon', 'time'], np.full([5, 10, 2], np.nan)),
+            'second': (['lat', 'lon', 'time'], np.full([5, 10, 2], np.nan)),
+            'lat': np.linspace(-89.5, 89.5, 5),
+            'lon': np.linspace(-179.5, 179.5, 10),
+            'time': pd.date_range('2000-01-01', periods=2)})
+
+        with create_tmp_file('remove_me', 'html') as tmp_file:
+            with self.assertRaises(ValueError):
+                animate_map(dataset,
+                            var='second',
+                            global_cmap=True,
+                            file=tmp_file)

--- a/test/ops/test_plot_helpers.py
+++ b/test/ops/test_plot_helpers.py
@@ -1,0 +1,96 @@
+"""
+Tests for plot and animation helper functions
+"""
+
+from unittest import TestCase
+
+import xarray as xr
+import numpy as np
+import pandas as pd
+
+from cate.ops.plot_helpers import check_bounding_box, in_notebook, get_var_data, determine_cmap_params
+
+
+class TestCheckBoundingBox(TestCase):
+    """
+    Test check_bounding_box()
+    """
+    def test_nominal(self):
+        """
+        Nominal test
+        """
+        self.assertTrue(check_bounding_box(10, 20, 10, 20))
+        self.assertFalse(check_bounding_box(20, 10, 10, 20))
+        self.assertFalse(check_bounding_box(10, 20, 20, 10))
+        self.assertFalse(check_bounding_box(-91, 10, 10, 20))
+        self.assertFalse(check_bounding_box(20, 91, 10, 20))
+        self.assertFalse(check_bounding_box(10, 20, -181, 20))
+        self.assertFalse(check_bounding_box(10, 20, 10, 181))
+
+
+class TestInNotebook(TestCase):
+    """
+    Test in_notebook()
+    """
+    def test_nominal(self):
+        """
+        Nominal test
+        """
+        self.assertFalse(in_notebook())
+
+
+class TestGetVarData(TestCase):
+    """
+    Test get_var_data()
+    """
+    def test_nominal(self):
+        """
+        Nominal test
+        """
+        dataset = xr.Dataset({
+            'first': (['lat', 'lon', 'time'], np.random.rand(5, 10, 2)),
+            'second': (['lat', 'lon', 'time'], np.random.rand(5, 10, 2)),
+            'lat': np.linspace(-89.5, 89.5, 5),
+            'lon': np.linspace(-179.5, 179.5, 10),
+            'time': pd.date_range('2000-01-01', periods=2)})
+
+        indexers = {'time': '2000-01-01', 'lat': -88}
+        out = get_var_data(dataset.second, indexers, remaining_dims=['lon', ])
+        self.assertEqual(out.time, np.datetime64('2000-01-01'))
+        self.assertEqual(out.lat, -89.5)
+        self.assertEqual(len(out.lon.values), 10)
+
+        indexers = {'lat': -88, }
+        out = get_var_data(dataset.second,
+                           indexers,
+                           remaining_dims=['lon', ],
+                           time=np.datetime64('2000-01-01'))
+        self.assertEqual(out.time, np.datetime64('2000-01-01'))
+        self.assertEqual(out.lat, -89.5)
+        self.assertEqual(len(out.lon.values), 10)
+
+
+class TestDetermineCmapParams(TestCase):
+    """
+    Test determine_cmap_params()
+    """
+    def test_nominal(self):
+        """
+        Nominal test
+        """
+        # Test nominal
+        cparams = determine_cmap_params(0, 100)
+        self.assertEqual(cparams['cmap'], 'viridis')
+
+        # Test divergent
+        cparams = determine_cmap_params(-100, 100)
+        self.assertEqual(cparams['cmap'], 'RdBu_r')
+
+        # Test extents
+        cparams = determine_cmap_params(0, 100, vmin=10, vmax=90)
+        self.assertEqual(cparams['extend'], 'both')
+
+        # Test levels
+        cparams = determine_cmap_params(0, 100, levels=3, vmin=10)
+        self.assertEqual(len(cparams['levels']), 3)
+        self.assertIsNotNone(cparams['norm'])


### PR DESCRIPTION
Don't merge this!

@forman, can you please provide feedback on this?

I've taken a stab at creating animations. There were multiple options around, but I chose using pure matplotlib functionality to not increase the dependency footprint.

The animation operation returns a stand alone HTML, as well as can save the animation into it. Matplotlib also allows for saving video formats and gifs, but that functionality requries ffmpeg, avconv and imagemagick installed on the host system. The HTML thing doesn't have external dependencies and it creates an animation with controls that can be used to slow it down, stop it, loop it, etc.

Works in a notebook as:
```python
import cate.ops as ops
from IPython.core.display import display, HTML
cc = ops.open_dataset('local.CLOUD_2008')
display(HTML(ops.animate_map(cc, var='cfc_low')))
```

As it returns HTML, I hope it should be easy enough to create a viewer in cate-desktop for it.

Haven't benchmarked it, but the operation shouldn't be memory hungry, as it only accesses slices one by one to create the animation. So it should work fine with large out of memory arrays too. I haven't yet added a monitor, but that should be straightforward enough.

The feedback I'd like to get is:
1. Is the general approach of using Matplotlib native stuff and HTML output fine?
2. Should the animation ops go into plot.py, or should we have them separate?
3. There are parts of plot operations that will overlap with parts of animation operations, do you think it should be refactored to have a bunch of helpers, or do you think code duplicates are fine here?
4. Any other thoughts on this?

Pending your approval, I plan to make an animation for the other plot method as well to allow generic animations to be made, implement monitors, try to make the operations cancellable and write some tests.