### PR TITLE
Pin xarray to 0.10.0 due to #579

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 ## Version 2.0.0.dev8 (in dev)
 
+* SST temporal aggregation error
+  [#548](https://github.com/CCI-Tools/cate/issues/548)
+* Scrambled time axis error
+  [#538](https://github.com/CCI-Tools/cate/issues/538)
+
 ## Version 2.0.0.dev7
 
 * Cate Desktop hangs after upgrading WebAPI to 2.0.0.dev6

--- a/environment.yml
+++ b/environment.yml
@@ -36,7 +36,8 @@ dependencies:
   - scipy >=0.19,<1.0
   - shapely >=1.6,<2.0
   - tornado >=5.0,<6.0
-  - xarray >=0.10,<1.0
+  # xarray >= 0.10.1 has an issue with time decoding see #579
+  - xarray ==0.10.0
   #
   # for testing only
   #


### PR DESCRIPTION
xarray >= 0.10.1 produces problems with time decoding (at least) for the SST dataset. See #579. Thus, pin the version in environment.yml.