### PR TITLE
update types.py

### DIFF
--- a/cate/core/types.py
+++ b/cate/core/types.py
@@ -81,7 +81,7 @@ class Like(Generic[T], metaclass=ABCMeta):
     #: A type that represents the varying source types. This is usually a ``typing.Union`` instance which
     #: combines the varying source types. The ``str`` type shall always be among them so that textual value
     #: representations are supported.
-    TYPE = None
+    TYPE = Any
 
     @classmethod
     def name(cls) -> str:


### PR DESCRIPTION
[Mypy](http://mypy-lang.org/) static linker complained in many dozens of places about type incompatibility when ``TYPE`` for ``class Like`` was ``None``. ``Any`` seems to fix this and seems to make more sense than ``None``, unless I misunderstand something. And the errors went away.