### PR TITLE
Jg 472 seasonal aggregation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ cate/bin
 # Used by Janis (VS Code)
 .mypy_cache/
 .vscode
+.pytest_cache/

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 ## Version 2.0.0.dev10 (in development)
 
-* Temporal aggregation operation can now aggregate so pre-defined seasons, as well as custom resolutions [#472](https://github.com/CCI-Tools/cate/issues/472)
+* Temporal aggregation operation can now aggregate to pre-defined seasons, as well as custom resolutions [#472](https://github.com/CCI-Tools/cate/issues/472)
 * We now use "MB" units instead of "MiB" (part of [#325](https://github.com/CCI-Tools/cate/issues/325))
 * Fixed a bug with animation generation [#585](https://github.com/CCI-Tools/cate/issues/585)
 * Upgrade to using newer xarray version after an upstream bugfix [#579](https://github.com/CCI-Tools/cate/issues/579)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ## Version 2.0.0.dev10 (in development)
 
+* Temporal aggregation operation can now aggregate so pre-defined seasons, as well as custom resolutions [#472](https://github.com/CCI-Tools/cate/issues/472)
 * We now use "MB" units instead of "MiB" (part of [#325](https://github.com/CCI-Tools/cate/issues/325))
 * Fixed a bug with animation generation [#585](https://github.com/CCI-Tools/cate/issues/585)
 * Upgrade to using newer xarray version after an upstream bugfix [#579](https://github.com/CCI-Tools/cate/issues/579)

--- a/cate/ops/aggregate.py
+++ b/cate/ops/aggregate.py
@@ -225,7 +225,7 @@ def _validate_freq(in_res: str, out_res: str) -> None:
     try:
         dates = pd.date_range('2000-01-01', periods=5, freq=out_res)
     except ValueError:
-        raise ValidationError('Invalid custom frequency: {}.'
+        raise ValidationError('Invalid custom resolution: {}.'
                               ' Please check operation documentation.'.format(out_res))
 
     # Assuming simple ISO_8601 periods: PXXD/M
@@ -234,6 +234,10 @@ def _validate_freq(in_res: str, out_res: str) -> None:
     except ValueError:
         raise ValidationError('Could not interpret time coverage resolution of'
                               ' the given dataset: {}'.format(in_res))
+
+    if in_res == 'P1M' and out_res == 'MS':
+        raise ValidationError('Input dataset is already at the requested output resolution.'
+                              'Execution stopped.')
 
     in_delta = pd.Timedelta(count, unit=in_res[-1])
     out_delta = dates[1] - dates[0]
@@ -244,8 +248,6 @@ def _validate_freq(in_res: str, out_res: str) -> None:
     elif out_delta == in_delta:
         raise ValidationError('Input dataset is already at the requested output resolution.'
                               'Execution stopped.')
-    else:
-        pass
 
     return
 

--- a/cate/ops/aggregate.py
+++ b/cate/ops/aggregate.py
@@ -147,7 +147,7 @@ def temporal_aggregation(ds: DatasetLike.TYPE,
                          custom_resolution: str = None,
                          monitor: Monitor = Monitor.NONE) -> xr.Dataset:
     """
-    Perform monthly aggregation of a daily dataset according to the given
+    Perform monthly aggregation of dataset according to the given
     method and output resolution.
 
     Note that the operation does not perform weighting. Depending on the
@@ -166,7 +166,7 @@ def temporal_aggregation(ds: DatasetLike.TYPE,
     Some examples:
       'QS-JUN' produces an output dataset on a quarterly resolution where the
       year ends in 1st of June and each quarter is denoted by its first date
-      '8MS' produces an output dataset on a five-month resolution where each
+      '8MS' produces an output dataset on an eight-month resolution where each
       period is denoted by the first date. Note that such periods will not be
       consistent over years.
       '8D' produces a dataset on an eight day resolution
@@ -174,7 +174,7 @@ def temporal_aggregation(ds: DatasetLike.TYPE,
     :param ds: Dataset to aggregate
     :param method: Aggregation method
     :param output_resolution: Desired temporal resolution of the output dataset
-    :param custom_resolution: A custom temporal resolution, overrides output_resolution
+    :param custom_resolution: Custom temporal resolution, overrides output_resolution
     :return: Aggregated dataset
     """
     ds = DatasetLike.convert(ds)
@@ -237,7 +237,7 @@ def _validate_freq(in_res: str, out_res: str) -> None:
 
     if in_res == 'P1M' and out_res == 'MS':
         raise ValidationError('Input dataset is already at the requested output resolution.'
-                              'Execution stopped.')
+                              ' Execution stopped.')
 
     in_delta = pd.Timedelta(count, unit=in_res[-1])
     out_delta = dates[1] - dates[0]

--- a/cate/ops/aggregate.py
+++ b/cate/ops/aggregate.py
@@ -136,19 +136,45 @@ def _mean(ds: xr.Dataset, monitor: Monitor, step: float):
 
 
 @op(tags=['aggregate', 'temporal'], version='1.1')
+@op_input('ds', data_type=DatasetLike)
 @op_input('method', value_set=['mean', 'max', 'median', 'prod', 'sum', 'std',
                                'var', 'argmax', 'argmin', 'first', 'last'])
-@op_input('ds', data_type=DatasetLike)
+@op_input('output_resolution', value_set=['month', 'season'])
 @op_return(add_history=True)
 def temporal_aggregation(ds: DatasetLike.TYPE,
                          method: str = 'mean',
+                         output_resolution: str = 'month',
+                         custom_resolution: str = None,
                          monitor: Monitor = Monitor.NONE) -> xr.Dataset:
     """
     Perform monthly aggregation of a daily dataset according to the given
-    method.
+    method and output resolution.
+
+    Note that the operation does not perform weighting. Depending on the
+    combination of input and output resolutions, as well as aggregation
+    method, the resulting dataset might yield unexpected results.
+
+    Resolution 'month' will result in a monthly dataset with each month
+    denoted by its first date. Resolution 'season' will result in a dataset
+    aggregated to DJF, MAM, JJA, SON seasons, each denoted by the first
+    date of the season.
+
+    The operation also works with custom resolution strings, see:
+    http://pandas.pydata.org/pandas-docs/stable/timeseries.html#offset-aliases
+    If ``custom_resolution`` is provided, it will override ``output_resolution``.
+
+    Some examples:
+      'QS-JUN' produces an output dataset on a quarterly resolution where the
+      year ends in June and each quarter is denoted by its first date
+      '8MS' produces an output dataset on a five-month resolution where each
+      period is denoted by the first date. Note that such periods will not be
+      consistent over years.
+      '8D' produces a dataset on an eight day resolution
 
     :param ds: Dataset to aggregate
     :param method: Aggregation method
+    :param output_resolution: Desired temporal resolution of the output dataset
+    :param custom_resolution: A custom temporal resolution, overrides output_resolution
     :return: Aggregated dataset
     """
     ds = DatasetLike.convert(ds)
@@ -159,17 +185,24 @@ def temporal_aggregation(ds: DatasetLike.TYPE,
                               ' {}. Running the normalize operation on this'
                               ' dataset may help'.format(ds.time.dtype))
 
-    # Check if we have a daily dataset
+    # Try to figure out the input frequency
     try:
-        if ds.attrs['time_coverage_resolution'] != 'P1D':
-            raise ValidationError('Temporal aggregation operation expects a daily dataset')
+        in_freq = ds.attrs['time_coverage_resolution']
     except KeyError:
-        raise ValidationError('Could not determine temporal resolution. Running'
-                              ' the adjust_temporal_attrs operation beforehand may'
+        raise ValidationError('Could not determine temporal resolution of input dataset.'
+                              ' Running the adjust_temporal_attrs operation beforehand may'
                               ' help.')
 
+    if custom_resolution:
+        freq = custom_resolution
+    else:
+        frequencies = {'month': 'MS', 'season': 'QS-NOV'}
+        freq = frequencies[output_resolution]
+
+    _validate_freq(in_freq, freq)
+
     with monitor.observing("resample dataset"):
-        retset = ds.resample(freq='MS', dim='time', keep_attrs=True, how=method)
+        retset = ds.resample(freq=freq, dim='time', keep_attrs=True, how=method)
 
     for var in retset.data_vars:
         try:
@@ -180,6 +213,41 @@ def temporal_aggregation(ds: DatasetLike.TYPE,
             retset[var].attrs['cell_methods'] = 'time: {} within years'.format(method)
 
     return adjust_temporal_attrs(retset)
+
+
+def _validate_freq(in_res: str, out_res: str) -> None:
+    """
+    Validate the aggregation step
+
+    See also: `ISO 8601 Durations <https://en.wikipedia.org/wiki/ISO_8601#Durations>`_
+    """
+    # Validate output frequency as a valid offset string
+    try:
+        dates = pd.date_range('2000-01-01', periods=5, freq=out_res)
+    except ValueError:
+        raise ValidationError('Invalid custom frequency: {}.'
+                              ' Please check operation documentation.'.format(out_res))
+
+    # Assuming simple ISO_8601 periods: PXXD/M
+    try:
+        count = int(in_res[1:-1])
+    except ValueError:
+        raise ValidationError('Could not interpret time coverage resolution of'
+                              ' the given dataset: {}'.format(in_res))
+
+    in_delta = pd.Timedelta(count, unit=in_res[-1])
+    out_delta = dates[1] - dates[0]
+
+    if out_delta < in_delta:
+        raise ValidationError('Requested output resolution is smaller than dataset resolution.'
+                              ' This operation only performs aggregation to larger resolutions.')
+    elif out_delta == in_delta:
+        raise ValidationError('Input dataset is already at the requested output resolution.'
+                              'Execution stopped.')
+    else:
+        pass
+
+    return
 
 
 @op(tags=['aggregate'], version='1.0')

--- a/cate/ops/aggregate.py
+++ b/cate/ops/aggregate.py
@@ -165,7 +165,7 @@ def temporal_aggregation(ds: DatasetLike.TYPE,
 
     Some examples:
       'QS-JUN' produces an output dataset on a quarterly resolution where the
-      year ends in June and each quarter is denoted by its first date
+      year ends in 1st of June and each quarter is denoted by its first date
       '8MS' produces an output dataset on a five-month resolution where each
       period is denoted by the first date. Note that such periods will not be
       consistent over years.
@@ -196,7 +196,7 @@ def temporal_aggregation(ds: DatasetLike.TYPE,
     if custom_resolution:
         freq = custom_resolution
     else:
-        frequencies = {'month': 'MS', 'season': 'QS-NOV'}
+        frequencies = {'month': 'MS', 'season': 'QS-DEC'}
         freq = frequencies[output_resolution]
 
     _validate_freq(in_freq, freq)

--- a/cate/ops/aggregate.py
+++ b/cate/ops/aggregate.py
@@ -135,7 +135,7 @@ def _mean(ds: xr.Dataset, monitor: Monitor, step: float):
     return retset
 
 
-@op(tags=['aggregate', 'temporal'], version='1.1')
+@op(tags=['aggregate', 'temporal'], version='1.5')
 @op_input('ds', data_type=DatasetLike)
 @op_input('method', value_set=['mean', 'max', 'median', 'prod', 'sum', 'std',
                                'var', 'argmax', 'argmin', 'first', 'last'])

--- a/test/ops/test_aggregate.py
+++ b/test/ops/test_aggregate.py
@@ -168,9 +168,57 @@ class TestTemporalAggregation(TestCase):
         Test aggergating to custom temporal resolutions
         """
         # daily -> 8 days
+        ds = xr.Dataset({
+            'first': (['lat', 'lon', 'time'], np.ones([45, 90, 366])),
+            'second': (['lat', 'lon', 'time'], np.ones([45, 90, 366])),
+            'lat': np.linspace(-88, 88, 45),
+            'lon': np.linspace(-178, 178, 90),
+            'time': pd.date_range('2000-01-01', '2000-12-31')})
+        ds = adjust_temporal_attrs(ds)
+
+        ex = xr.Dataset({
+            'first': (['lat', 'lon', 'time'], np.ones([45, 90, 46])),
+            'second': (['lat', 'lon', 'time'], np.ones([45, 90, 46])),
+            'lat': np.linspace(-88, 88, 45),
+            'lon': np.linspace(-178, 178, 90),
+            'time': pd.date_range('2000-01-01', '2000-12-31', freq='8D')})
+        ex.first.attrs['cell_methods'] = 'time: mean within years'
+        ex.second.attrs['cell_methods'] = 'time: mean within years'
+        m = ConsoleMonitor()
+        actual = temporal_aggregation(ds, custom_resolution='8D', monitor=m)
+        self.assertTrue(actual.broadcast_equals(ex))
+
         # daily -> weekly
+        ex = xr.Dataset({
+            'first': (['lat', 'lon', 'time'], np.ones([45, 90, 53])),
+            'second': (['lat', 'lon', 'time'], np.ones([45, 90, 53])),
+            'lat': np.linspace(-88, 88, 45),
+            'lon': np.linspace(-178, 178, 90),
+            'time': pd.date_range('2000-01-01', '2000-12-31', freq='W')})
+        ex.first.attrs['cell_methods'] = 'time: mean within years'
+        ex.second.attrs['cell_methods'] = 'time: mean within years'
+        actual = temporal_aggregation(ds, custom_resolution='W', monitor=m)
+        self.assertTrue(actual.broadcast_equals(ex))
+
         # monthly -> 4 month seasons
-        pass
+        ds = xr.Dataset({
+            'first': (['lat', 'lon', 'time'], np.ones([45, 90, 12])),
+            'second': (['lat', 'lon', 'time'], np.ones([45, 90, 12])),
+            'lat': np.linspace(-88, 88, 45),
+            'lon': np.linspace(-178, 178, 90),
+            'time': pd.date_range('2000-01-01', freq='MS', periods=12)})
+        ds = adjust_temporal_attrs(ds)
+        ex = xr.Dataset({
+            'first': (['lat', 'lon', 'time'], np.ones([45, 90, 4])),
+            'second': (['lat', 'lon', 'time'], np.ones([45, 90, 4])),
+            'lat': np.linspace(-88, 88, 45),
+            'lon': np.linspace(-178, 178, 90),
+            'time': pd.date_range('2000-01-01', freq='4M', periods=4)})
+        ex.first.attrs['cell_methods'] = 'time: mean within years'
+        ex.second.attrs['cell_methods'] = 'time: mean within years'
+        actual = temporal_aggregation(ds, custom_resolution='4M', monitor=m)
+        print(actual)
+        self.assertTrue(actual.broadcast_equals(ex))
 
     def test_8days(self):
         """

--- a/test/ops/test_aggregate.py
+++ b/test/ops/test_aggregate.py
@@ -132,8 +132,36 @@ class TestTemporalAggregation(TestCase):
         Test aggregation to a seasonal dataset
         """
         # daily -> seasonal
+        ds = xr.Dataset({
+            'first': (['lat', 'lon', 'time'], np.ones([45, 90, 366])),
+            'second': (['lat', 'lon', 'time'], np.ones([45, 90, 366])),
+            'lat': np.linspace(-88, 88, 45),
+            'lon': np.linspace(-178, 178, 90),
+            'time': pd.date_range('2000-01-01', '2000-12-31')})
+        ds = adjust_temporal_attrs(ds)
+
+        ex = xr.Dataset({
+            'first': (['lat', 'lon', 'time'], np.ones([45, 90, 5])),
+            'second': (['lat', 'lon', 'time'], np.ones([45, 90, 5])),
+            'lat': np.linspace(-88, 88, 45),
+            'lon': np.linspace(-178, 178, 90),
+            'time': pd.date_range('1999-12-01', freq='QS-DEC', periods=5)})
+        ex.first.attrs['cell_methods'] = 'time: mean within years'
+        ex.second.attrs['cell_methods'] = 'time: mean within years'
+        m = ConsoleMonitor()
+        actual = temporal_aggregation(ds, output_resolution='season', monitor=m)
+        self.assertTrue(actual.broadcast_equals(ex))
+
         # monthly -> seasonal
-        pass
+        ds = xr.Dataset({
+            'first': (['lat', 'lon', 'time'], np.ones([45, 90, 12])),
+            'second': (['lat', 'lon', 'time'], np.ones([45, 90, 12])),
+            'lat': np.linspace(-88, 88, 45),
+            'lon': np.linspace(-178, 178, 90),
+            'time': pd.date_range('2000-01-01', freq='MS', periods=12)})
+        ds = adjust_temporal_attrs(ds)
+        actual = temporal_aggregation(ds, output_resolution='season', monitor=m)
+        self.assertTrue(actual.broadcast_equals(ex))
 
     def test_custom(self):
         """


### PR DESCRIPTION
``temporal_aggregation`` now is a lot more flexible - works with arbitrary datasets and aggregates to ``month``, ``season`` or ``custom_resolution``, which can be denoted using Pandas [date offset aliases](https://pandas.pydata.org/pandas-docs/stable/timeseries.html#offset-aliases)