### PR TITLE
Coerce chunking along time dimension

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,9 @@
 * Fixed division by zero error in RGB tile generation if data min and max were equal 
 * Allow displaying and working with CCI Sea Level MSLAMPH data.
   Addresses [#531](https://github.com/CCI-Tools/cate/issues/531).
+* Improved chunking when opening local netCDF datasets, improved memory footprint of
+  ``subset_spatial`` operation when masking is enabled
+  Addresses [#701](https://github.com/CCI-Tools/cate/issues/701)
 
 ## Version 2.0.0.dev15
 

--- a/cate/core/opimpl.py
+++ b/cate/core/opimpl.py
@@ -851,22 +851,21 @@ def subset_spatial_impl(ds: xr.Dataset,
         # Create a mask directly on pixel centers
         lonm, latm = np.meshgrid(retset.lon.values, retset.lat.values)
         grid_points = [(lon, lat) for lon, lat in zip(lonm.ravel(), latm.ravel())]
-        mask = polypath.contains_points(grid_points)
-        mask = mask.reshape(lonm.shape)
-        mask = xr.DataArray(mask,
-                            coords={'lon': retset.lon.values, 'lat': retset.lat.values},
-                            dims=['lat', 'lon'])
+        mask_arr = polypath.contains_points(grid_points)
+        mask_arr = mask_arr.reshape(lonm.shape)
+        mask_arr = xr.DataArray(mask_arr,
+                                coords={'lon': retset.lon.values, 'lat': retset.lat.values},
+                                dims=['lat', 'lon'])
 
         with monitor.observing('subset'):
             # Apply the mask to data
-            retset = retset.where(mask, drop=True)
+            retset = retset.where(mask_arr, drop=True)
         return retset
 
     # The normal case
     # Create a grid of pixel vertices
     lon_pixel = abs(ds.lon.values[1] - ds.lon.values[0])
     lat_pixel = abs(ds.lat.values[1] - ds.lat.values[0])
-
     lon_min = retset.lon.values[0] - lon_pixel / 2
     lon_max = retset.lon.values[-1] + lon_pixel / 2
     lat_min = retset.lat.values[0] - lat_pixel / 2
@@ -883,21 +882,21 @@ def subset_spatial_impl(ds: xr.Dataset,
     grid_points = [(lon, lat) for lon, lat in zip(lonm.ravel(), latm.ravel())]
 
     monitor.progress(1)
-    mask = polypath.contains_points(grid_points)
+    mask_arr = polypath.contains_points(grid_points)
 
     monitor.progress(1)
 
-    mask = mask.reshape(lonm.shape)
+    mask_arr = mask_arr.reshape(lonm.shape)
     # Vectorized 'rolling window' numpy magic to go from pixel vertices to pixel centers
-    mask = mask[1:, 1:] + mask[1:, :-1] + mask[:-1, 1:] + mask[:-1, :-1]
+    mask_arr = mask_arr[1:, 1:] + mask_arr[1:, :-1] + mask_arr[:-1, 1:] + mask_arr[:-1, :-1]
 
-    mask = xr.DataArray(mask,
-                        coords={'lon': retset.lon.values, 'lat': retset.lat.values},
-                        dims=['lat', 'lon'])
+    mask_arr = xr.DataArray(mask_arr,
+                            coords={'lon': retset.lon.values, 'lat': retset.lat.values},
+                            dims=['lat', 'lon'])
 
     with monitor.observing('subset'):
         # Apply the mask to data
-        retset = retset.where(mask, drop=True)
+        retset = retset.where(mask_arr, drop=False)
 
     monitor.done()
     return retset
@@ -1020,7 +1019,7 @@ def _normalize_dim_order(ds: xr.Dataset) -> xr.Dataset:
         if num_dims >= 2 and 'lat' in dim_names and 'lon' in dim_names:
             lat_index = dim_names.index('lat')
             if lat_index != num_dims - 2:
-               must_transpose = _swap_pos(dim_names, lat_index, -2)
+                must_transpose = _swap_pos(dim_names, lat_index, -2)
             lon_index = dim_names.index('lon')
             if lon_index != num_dims - 1:
                 must_transpose = _swap_pos(dim_names, lon_index, -1)

--- a/cate/ops/io.py
+++ b/cate/ops/io.py
@@ -507,6 +507,8 @@ def read_netcdf(file: str,
                          decode_times=decode_times,
                          engine=engine)
     chunks = get_spatial_ext_chunk_sizes(ds)
+    if chunks and 'time' in ds.dims:
+        chunks['time'] = 1
     if chunks:
         ds = ds.chunk(chunks)
     if normalize:

--- a/cate/ops/normalize.py
+++ b/cate/ops/normalize.py
@@ -29,12 +29,10 @@ Components
 ==========
 """
 
-import numpy as np
 import xarray as xr
 
-from cate.core.op import op, op_return, op_input
+from cate.core.op import op, op_return
 from cate.core.opimpl import normalize_impl, adjust_temporal_attrs_impl, adjust_spatial_attrs_impl
-from cate.core.types import DatasetLike
 
 
 @op(tags=['utility'], version='1.0')


### PR DESCRIPTION
The ``read_netcdf`` implementation only provides chunks along spatial
dimensions. This results in all other dimensions including 'time' not
getting chunked. This creates problems later on with retrieving the
computation results for viewing.

The 'time' dimension now gets chunked such that each time
slice is a different chunk, which is a good assumption in
most cases and works well with the given data

Closes #698