### PR TITLE
Jg 700 pearson correlation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
 * Improved chunking when opening local netCDF datasets, improved memory footprint of
   ``subset_spatial`` operation when masking is enabled
   Addresses [#701](https://github.com/CCI-Tools/cate/issues/701)
+* Fix a bug where correlation would fail with differing time dimensions
+  Addresses [#700](https://github.com/CCI-Tools/cate/issues/700)
 
 ## Version 2.0.0.dev15
 

--- a/cate/ops/correlation.py
+++ b/cate/ops/correlation.py
@@ -245,6 +245,8 @@ def _pearsonr(x: xr.DataArray, y: xr.DataArray, monitor: Monitor) -> xr.Dataset:
         n = len(x['time'])
 
         xm, ym = x - x.mean(dim='time'), y - y.mean(dim='time')
+        xm.time.values = [i for i in range(0, len(xm.time))]
+        ym.time.values = [i for i in range(0, len(ym.time))]
         xm_ym = xm * ym
         r_num = xm_ym.sum(dim='time')
         xm_squared = xr.ufuncs.square(xm)

--- a/test/ops/test_correlation.py
+++ b/test/ops/test_correlation.py
@@ -140,6 +140,25 @@ class TestPearson(TestCase):
         self.assertTrue(np.all(np.isclose(correlation['p_value'].values,
                                           pv_sp)))
 
+        # Test non-overlapping times
+        ds1 = xr.Dataset({
+            'first': (['lat', 'lon', 'time'], x_3d),
+            'lat': np.linspace(-67.5, 67.5, 4),
+            'lon': np.linspace(-157.5, 157.5, 8),
+            'time': np.linspace(0, 5, 6)})
+
+        ds2 = xr.Dataset({
+            'first': (['lat', 'lon', 'time'], y_3d),
+            'lat': np.linspace(-67.5, 67.5, 4),
+            'lon': np.linspace(-157.5, 157.5, 8),
+            'time': np.linspace(6, 11, 6)})
+
+        correlation = pearson_correlation(ds1, ds2, 'first', 'first')
+        self.assertTrue(np.all(np.isclose(correlation['corr_coef'].values,
+                                          cc_sp)))
+        self.assertTrue(np.all(np.isclose(correlation['p_value'].values,
+                                          pv_sp)))
+
     def test_broadcasting(self):
         """
         Test a (3d, 1d) input pair


### PR DESCRIPTION
Fix #700, by making sure having non-overlapping time dimensions does not prevent the operation from running successfully.