### PR TITLE
Make sure a tuple of lat/lon is read from json

### DIFF
--- a/cate/core/types.py
+++ b/cate/core/types.py
@@ -591,6 +591,20 @@ class PolygonLike(GeometryLike, Like[shapely.geometry.Polygon]):
         return polygon
 
     @classmethod
+    def from_json(cls, value: Any) -> Optional[T]:
+        """
+        Deserialize the given JSON value into a value of target type *T*.
+
+        :param value: a JSON value
+        :return: a optional value of target type *T*
+        """
+        if cls.convert(value):
+            # We want to preserve tuples if that's how a polygon was defined
+            return value
+        else:
+            return None
+
+    @classmethod
     def format(cls, value: Optional[shapely.geometry.Polygon]) -> str:
         return value.wkt if value else ''
 

--- a/test/core/test_types.py
+++ b/test/core/test_types.py
@@ -372,6 +372,9 @@ class PolygonLikeTest(TestCase):
         pol = PolygonLike.convert(coords)
         self.assertEqual(PolygonLike.format(pol), 'POLYGON ((10.4 20.2, 30.8 20.2, 30.8 40.8, 10.4 40.8, 10.4 20.2))')
 
+    def test_json(self):
+        self.assertEqual(PolygonLike.from_json("-10, -10, 10, 10"), "-10, -10, 10, 10")
+
 
 class GeometryLikeTest(TestCase):
 


### PR DESCRIPTION
A tuple of lat/lon values should not be converted to
a Shapely polygon upon reading from json, as this
loses information.

Closes 693