### PR TITLE
Make sure integer data arrays can be coregistered

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 ## Version 2.0.0.dev21 (in development)
 
+* Make sure integer data variables can be coregistered [#770](https://github.com/CCI-Tools/cate/issues/770)
+
 ## Version 2.0.0.dev20
 
 * Changed order and names of new `data_frame_subset` operation inputs.

--- a/cate/ops/resampling.py
+++ b/cate/ops/resampling.py
@@ -529,7 +529,7 @@ def _downsample_2d(src, mask, use_mask, method, fill_value, mode_rank, out):
                 else:
                     out[out_y, out_x] = (wvv_sum * w_sum - wv_sum * wv_sum) / w_sum / w_sum
         if method == DS_STD:
-            out = np.sqrt(out)
+            out = np.sqrt(out).astype(out.dtype)
     else:
         raise ValueError('invalid downsampling method')
 


### PR DESCRIPTION
There was a numba typing issue in the 'gridtools' code we had
incorporated, that would prevent the downsampling code from
compiling if a non-float datatype is used. Fix borrowed from upstream.

Closes #770 