### PR TITLE
Jg 733 coreg

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 * Pearson correlation scalar operation now works on N-D data variables [#746](https://github.com/CCI-Tools/cate/issues/746)
 * Make sure integer data variables can be coregistered [#770](https://github.com/CCI-Tools/cate/issues/770)
+* Fix an issue with coregistering datasets with inverted latitudes [#733](https://github.com/CCI-Tools/cate/issues/733)
 
 
 ## Version 2.0.0.dev20

--- a/cate/core/objectio.py
+++ b/cate/core/objectio.py
@@ -100,7 +100,7 @@ def write_object(obj, file, format_name=None, **kwargs):
     writer = find_writer(obj, file, format_name=format_name, **kwargs)
     if not writer:
         msg = f"no writer found for format {format_name}" if format_name else "no writer found"
-        raise ValueError()
+        raise ValueError(msg)
     writer.write(obj, file, **kwargs)
     return writer
 

--- a/cate/core/objectio.py
+++ b/cate/core/objectio.py
@@ -78,10 +78,11 @@ def read_object(file, format_name=None, **kwargs):
     :return: A tuple (*obj*, *reader*), where *obj* is the object read and *reader* is the reader used to read it.
     """
     if not os.path.exists(file):
-        raise FileNotFoundError('file not found: %s' % file)
+        raise FileNotFoundError(f'file not found: {file}')
     reader = find_reader(file, format_name=format_name, **kwargs)
     if not reader:
-        raise ValueError("no reader found for format '%s'" % format_name if format_name else "no reader found")
+        msg = f"no reader found for format {format_name}" if format_name else "no reader found"
+        raise ValueError(msg)
     obj = reader.read(file, **kwargs)
     return obj, reader
 
@@ -98,7 +99,8 @@ def write_object(obj, file, format_name=None, **kwargs):
     """
     writer = find_writer(obj, file, format_name=format_name, **kwargs)
     if not writer:
-        raise ValueError("no writer found for format '%s'" % format_name if format_name else "no writer found")
+        msg = f"no writer found for format {format_name}" if format_name else "no writer found"
+        raise ValueError()
     writer.write(obj, file, **kwargs)
     return writer
 

--- a/cate/core/opimpl.py
+++ b/cate/core/opimpl.py
@@ -65,8 +65,24 @@ def normalize_impl(ds: xr.Dataset) -> xr.Dataset:
     ds = _normalize_lat_lon_2d(ds)
     ds = _normalize_dim_order(ds)
     ds = _normalize_lon_360(ds)
+    ds = _normalize_inverted_lat(ds)
     ds = normalize_missing_time(ds)
     ds = _normalize_jd2datetime(ds)
+    return ds
+
+
+def _normalize_inverted_lat(ds: xr.Dataset) -> xr.Dataset:
+    """
+    In case the latitude decreases, invert it
+    :param ds: some xarray dataset
+    :return: a normalized xarray dataset
+    """
+    try:
+        if _lat_inverted(ds.lat):
+            ds = ds.sel(lat=slice(None, None, -1))
+    except AttributeError:
+        # The dataset doesn't have 'lat', probably not geospatial
+        pass
     return ds
 
 

--- a/cate/core/opimpl.py
+++ b/cate/core/opimpl.py
@@ -83,6 +83,9 @@ def _normalize_inverted_lat(ds: xr.Dataset) -> xr.Dataset:
     except AttributeError:
         # The dataset doesn't have 'lat', probably not geospatial
         pass
+    except ValueError:
+        # The dataset still has an ND 'lat' array
+        pass
     return ds
 
 

--- a/cate/ops/arithmetics.py
+++ b/cate/ops/arithmetics.py
@@ -41,7 +41,6 @@ import scipy
 import scipy as sp
 import xarray
 import xarray as xr
-from xarray import ufuncs as xu
 
 from cate.core.op import op, op_input, op_return
 from cate.core.types import DatasetLike, ValidationError, DataFrameLike
@@ -94,15 +93,15 @@ def ds_arithmetics(ds: DatasetLike.TYPE,
                 elif item[0] == '/':
                     retset = retset / float(item[1:])
                 elif item[:] == 'log':
-                    retset = xu.log(retset)
+                    retset = np.log(retset)
                 elif item[:] == 'log10':
-                    retset = xu.log10(retset)
+                    retset = np.log10(retset)
                 elif item[:] == 'log2':
-                    retset = xu.log2(retset)
+                    retset = np.log2(retset)
                 elif item[:] == 'log1p':
-                    retset = xu.log1p(retset)
+                    retset = np.log1p(retset)
                 elif item[:] == 'exp':
-                    retset = xu.exp(retset)
+                    retset = np.exp(retset)
                 else:
                     raise ValidationError('Arithmetic operation {} not'
                                           ' implemented.'.format(item[0]))

--- a/test/ops/test_normalize.py
+++ b/test/ops/test_normalize.py
@@ -118,8 +118,8 @@ class TestNormalize(TestCase):
             'second': (['time', 'lat', 'lon'], np.zeros([3, 45, 90])),
             'lat': np.linspace(88, -88, 45),
             'lon': np.linspace(-178, 178, 90),
-            'time': [datetime(2000, x, 1) for x in range(1, 4)]}).chunk(chunks={'time':1})
-            
+            'time': [datetime(2000, x, 1) for x in range(1, 4)]}).chunk(chunks={'time': 1})
+
         first = np.zeros([3, 45, 90])
         first[0, :, :] = np.flip(np.eye(45, 90), axis=0)
         expected = xr.Dataset({
@@ -127,11 +127,10 @@ class TestNormalize(TestCase):
             'second': (['time', 'lat', 'lon'], np.zeros([3, 45, 90])),
             'lat': np.linspace(-88, 88, 45),
             'lon': np.linspace(-178, 178, 90),
-            'time': [datetime(2000, x, 1) for x in range(1, 4)]}).chunk(chunks={'time':1})
-        
+            'time': [datetime(2000, x, 1) for x in range(1, 4)]}).chunk(chunks={'time': 1})
+
         actual = normalize(ds)
         xr.testing.assert_equal(actual, expected)
-
 
     def test_normalize_with_missing_time_dim(self):
         ds = xr.Dataset({'first': (['lat', 'lon'], np.zeros([90, 180])),


### PR DESCRIPTION
The issue in #733 was that one of the datasets (Ocean Color) had 'inverted' latitude. Previously I managed such cases separately in each operation. It quickly became somewhat troublesome to do that in coregistration. So, I made a decision to take care of inverting the latitude as part of ``normalization``. Based on the following reasons:

1. It is a bit ugly to have to take care of two possible latitude directions in many places
2. It is easy to do once and it works well with ``xarray``, ``dask`` and ``numpy`` providing a view of the original data
3. Although a dataset with decreasing ``lat`` values is a very 'normal' dataset, it's still nice to have harmonized datasets within ``cate``, and other things we normalize for are often also very 'normal' things otherwise.