### PR TITLE
Allow CORS in Cate Web API

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 ## Version 2.1.0 (in development)
 
+* Cate Web API allows for Cross-Origin Resource Sharing (CORS), which is required
+  to run Cate UI in a browser.
 * Added option `--traceback` to `cate-webapi-start` and `cate-webapi-stop` CLI tools.
 * Added operation `write_zarr()` to write gridded datasets using the Zarr format.
 * Updated `cate.core.wsmanag.WorkspaceManager` to work only with workspace paths relative to a given

--- a/cate/util/web/webapi.py
+++ b/cate/util/web/webapi.py
@@ -42,6 +42,7 @@ from tornado.web import RequestHandler, Application
 from .common import exception_to_json
 from .serviceinfo import read_service_info, write_service_info, \
     find_free_port, is_service_compatible, is_service_running, join_address_and_port
+from ...version import __version__
 
 __author__ = "Norman Fomferra (Brockmann Consult GmbH), " \
              "Marco Zühlke (Brockmann Consult GmbH)"
@@ -632,6 +633,12 @@ class WebAPIRequestHandler(RequestHandler):
             else:
                 return dict(status='error', error=dict(message=message))
         return dict(status='error')
+
+    def set_default_headers(self) -> None:
+        self.set_header("Access-Control-Allow-Origin", "*")
+        self.set_header("Access-Control-Allow-Headers", "x-requested-with")
+        self.set_header('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
+        self.set_header('User-Agent', f'Cate WebAPI/{__version__}')
 
 
 class _GlobalEventLoopPolicy(asyncio.DefaultEventLoopPolicy):


### PR DESCRIPTION
Cate Web API allows for Cross-Origin Resource Sharing (CORS), which is required to run Cate UI in a browser.

Fixes https://github.com/CCI-Tools/cate-webui/issues/15.
