### PR TITLE
Fixes buggy WebAPIInfoHandler

### DIFF
--- a/cate/version.py
+++ b/cate/version.py
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 # Cate version string (PEP440-compatible), e.g. "0.8.0", "0.8.0.dev1", "0.8.0rc1", "0.8.0rc1.dev1"
-__version__ = '2.1.0.dev0'
+__version__ = '2.1.0.dev1'
 
 # Other package metainfo
 __title__ = 'cate'

--- a/cate/webapi/start.py
+++ b/cate/webapi/start.py
@@ -75,7 +75,7 @@ __author__ = "Norman Fomferra (Brockmann Consult GmbH), " \
 # noinspection PyAbstractClass
 class WebAPIInfoHandler(WebAPIRequestHandler):
     def get(self):
-        user_root_mode = self.application.root_dir is not None
+        user_root_mode = isinstance(self.application.workspace_manager, RelativeFSWorkspaceManager)
 
         self.write_status_ok(content={'name': SERVICE_NAME,
                                       'version': __version__,


### PR DESCRIPTION
This PR:

* Fixes buggy WebAPIInfoHandler which crashed on invocation, because `self.application.root_dir` was never set