### PR TITLE
Suvi catehub docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -30,8 +30,8 @@ MOCK_MODULES = ['geopandas', 'cartopy', 'cartopy.crs', 'fiona', 'numba', 'pandas
                 'matplotlib', 'matplotlib.animation', 'matplotlib.cm', 'matplotlib.figure', 'matplotlib.pyplot',
                 'matplotlib.backends.backend_webagg_core',
                 'pyproj', 'scipy', 'scipy.stats', 'scipy.special',
-                'shapely', 'shapely.errors', 'shapely.wkt', 'shapely.geometry', 'shapely.geometry.base',
-                'xarray', 'xarray.backends',
+                'shapely', 'shapely.errors', 'shapely.wkt', 'shapely.geometry', 'shapely.geometry.base', 'shapely.ops'
+                'xarray', 'xarray.backends', 'xarray.core.resample',
                 'dask', 'dask.callbacks',
                 'numpy', 'jdcal', 'dateutil', 'owslib', 'owslib.csw', 'owslib.namespaces', 'psutil']
 for mod_name in MOCK_MODULES:

--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -2,4 +2,5 @@ sphinx>=2.0
 sphinx_rtd_theme>=0.4.3
 sphinx-argparse
 sphinx-autodoc-annotation
+mock
 recommonmark>=0.6.0

--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -1,3 +1,5 @@
 sphinx>=2.0
 sphinx_rtd_theme>=0.4.3
+sphinx-argparse
+sphinx-autodoc-annotation
 recommonmark>=0.6.0

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -10,8 +10,9 @@ sphinx:
     configuration: docs/source/conf.py
 
 # The path to the Conda environment file, relative to the root of the project.
-conda:
-    environment: environment.yml
+# conda installation currently creates insufficient memory issue on RTD.
+#conda:
+#    environment: environment.yml
 
 # The path to the pip requirements file.
 # Optionally set the version of Python and requirements required to build your docs

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -16,10 +16,10 @@ conda:
 # The path to the pip requirements file.
 # Optionally set the version of Python and requirements required to build your docs
 python:
-    setup_py_install: true
     install:
         - requirements: docs/source/requirements.txt
-
+        - method: setuptools
+          path: cate
 # Optionally build your docs in additional formats such as PDF and ePub
 formats: all
 

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -20,7 +20,7 @@ python:
     install:
         - requirements: docs/source/requirements.txt
         - method: setuptools
-          path: cate
+          path: .
 # Optionally build your docs in additional formats such as PDF and ePub
 formats: all
 


### PR DESCRIPTION
hopefully fixes #878 ( failing docs on RTD). but doesn't look like RTD is building docs on branches so one way to know if it worked is to merge to master(?)

- Changed to readthedocs.yml to match readthedocs v2 spec, specifically one setup_py_install to method:setuptools as described in: https://docs.readthedocs.io/en/stable/config-file/v2.html#migrating-from-v1
- Couple of dependencies were added to docs/requirements.txt that were needed for local doc build.