### PR TITLE
use dsr ids to determine data source ids

### DIFF
--- a/cate/ds/esa_cci_odp.py
+++ b/cate/ds/esa_cci_odp.py
@@ -761,25 +761,15 @@ class EsaCciOdpDataStore(DataStore):
         self._adjust_json_dict_for_param(json_dict, 'product_string', 'product_strings', values[7])
         self._adjust_json_dict_for_param(json_dict, 'product_version', 'product_versions', values[8])
 
-    def _convert_time_from_drs_id(self, time_value: str) -> str:
-        if time_value == 'mon' or time_value == 'month':
-            return 'month'
-        if time_value == 'yr' or time_value == 'year':
-            return 'year'
-        if time_value == 'day':
-            return 'day'
-        if time_value == 'satellite-orbit-frequency':
-            return 'satellite-orbit-frequency'
-        if time_value == '5-days':
-            return '5 days'
-        if time_value == '8-days':
-            return '8 days'
-        if time_value == '15-days':
-            return '15 days'
-        if time_value == '13-yrs':
-            return '13 years'
-        if time_value == 'climatology':
-            return 'climatology'
+    @staticmethod
+    def _convert_time_from_drs_id(time_value: str) -> str:
+        time_value_lookup = {'mon': 'month', 'month': 'month', 'yr': 'year', 'year': 'year', 'day': 'day',
+                             'satellite-orbit-frequency': 'satellite-orbit-frequency', 'climatology': 'climatology'}
+        if time_value in time_value_lookup:
+            return time_value_lookup[time_value]
+        if re.match('[0-9]+-[days|yrs]', time_value):
+            split_time_value = time_value.split('-')
+            return f'{split_time_value[0]} {split_time_value[1].replace("yrs", "years")}'
         raise ValueError('Unknown time frequency format')
 
     def _adjust_json_dict_for_param(self, json_dict: dict, single_name: str, list_name: str, param_value: str):
@@ -952,27 +942,6 @@ class EsaCciOdpDataSource(DataSource):
         self._file_list = None
         self._meta_info = None
         self._temporal_coverage = None
-
-    def _convert_time_from_drs_id(self, time_value: str) -> str:
-        if time_value == 'mon' or time_value == 'month':
-            return 'month'
-        if time_value == 'yr' or time_value == 'year':
-            return 'year'
-        if time_value == 'day':
-            return 'day'
-        if time_value == 'satellite-orbit-frequency':
-            return 'satellite-orbit-frequency'
-        if time_value == '5-days':
-            return '5 days'
-        if time_value == '8-days':
-            return '8 days'
-        if time_value == '15-days':
-            return '15 days'
-        if time_value == '13-yrs':
-            return '13 years'
-        if time_value == 'climatology':
-            return 'climatology'
-        raise ValueError('Unknown time frequency format')
 
     @property
     def id(self) -> str:

--- a/cate/ds/esa_cci_odp.py
+++ b/cate/ds/esa_cci_odp.py
@@ -191,10 +191,11 @@ async def _extract_metadata_from_descxml_url(session=None, descxml_url: str = No
         return {}
     resp = await session.request(method='GET', url=descxml_url)
     resp.raise_for_status()
-    descxml = etree.XML(await resp.read())
+    content = await resp.read()
     try:
+        descxml = etree.XML(content)
         return _extract_metadata_from_descxml(descxml)
-    except etree.ParseError:
+    except etree.XMLSyntaxError:
         _LOG.info(f'Cannot read metadata from {descxml_url} due to parsing error.')
         return {}
 

--- a/cate/ds/esa_cci_odp.py
+++ b/cate/ds/esa_cci_odp.py
@@ -510,18 +510,10 @@ async def _fetch_meta_info(dataset_id: str, odd_url: str, metadata_url: str, var
         return meta_info_dict
 
 
-async def _fetch_file_list_json(dataset_id: str, time_frequency: str, processing_level: str, data_type: str,
-                                sensor_id: str, platform_id: str, product_string: str, product_version: str,
-                                monitor: Monitor = Monitor.NONE) -> Sequence:
+async def _fetch_file_list_json(dataset_id: str, drs_id: str, monitor: Monitor = Monitor.NONE) -> Sequence:
     feature_list = await _fetch_opensearch_feature_list(_OPENSEARCH_CEDA_URL,
                                                         dict(parentIdentifier=dataset_id,
-                                                             frequency=time_frequency,
-                                                             processingLevel=processing_level,
-                                                             dataType=data_type,
-                                                             sensor=sensor_id,
-                                                             platform=platform_id,
-                                                             productString=product_string,
-                                                             productVersion=product_version,
+                                                             drsId=drs_id,
                                                              fileFormat='.nc'),
                                                         monitor=monitor)
     file_list = []
@@ -741,45 +733,54 @@ class EsaCciOdpDataStore(DataStore):
                                               cache_json_filename='meta-info.json',
                                               cache_timestamp_filename='meta-info-timestamp.txt',
                                               cache_expiration_days=self.index_cache_expiration_days)
-        time_frequencies = self._get_as_list(meta_info, 'time_frequency', 'time_frequencies')
-        processing_levels = self._get_as_list(meta_info, 'processing_level', 'processing_levels')
-        data_types = self._get_as_list(meta_info, 'data_type', 'data_types')
-        sensor_ids = self._get_as_list(meta_info, 'sensor_id', 'sensor_ids')
-        platform_ids = self._get_as_list(meta_info, 'platform_id', 'platform_ids')
-        product_strings = self._get_as_list(meta_info, 'product_string', 'product_strings')
-        product_versions = self._get_as_list(meta_info, 'product_version', 'product_versions')
         drs_ids = self._get_as_list(meta_info, 'drs_id', 'drs_ids')
-        if not time_frequencies or not processing_levels or not data_types or not sensor_ids or not platform_ids \
-                or not product_strings or not product_versions or not drs_ids:
-            return
-        drs_id = drs_ids[0].split('.')[-1]
-        it = itertools.product(time_frequencies, processing_levels, data_types, sensor_ids, platform_ids,
-                               product_strings, product_versions)
-        value_tuples = list(it)
         with open(os.path.join(os.path.dirname(__file__), 'data/excluded_data_sources')) as fp:
             excluded_data_sources = fp.read().split('\n')
-            for value_tuple in value_tuples:
-                pretty_id = self._get_pretty_id(meta_info, value_tuple, drs_id)
-                if pretty_id in excluded_data_sources:
+            for drs_id in drs_ids:
+                if drs_id in excluded_data_sources:
                     continue
-                if pretty_id in set([ds.id for ds in self._data_sources]):
-                    _LOG.warning(f'Data source {pretty_id} already included. Will omit this one.')
+                if drs_id in set([ds.id for ds in self._data_sources]):
+                    _LOG.warning(f'Data source {drs_id} already included. Will omit this one.')
                     continue
                 meta_info = meta_info.copy()
                 meta_info.update(json_dict)
-                self._adjust_json_dict(meta_info, value_tuple)
+                self._adjust_json_dict(meta_info, drs_id)
                 meta_info['cci_project'] = meta_info['ecv']
-                data_source = EsaCciOdpDataSource(self, meta_info, datasource_id, pretty_id, value_tuple)
+                meta_info['fid'] = datasource_id
+                data_source = EsaCciOdpDataSource(self, meta_info, datasource_id, drs_id)
                 self._data_sources.append(data_source)
 
-    def _adjust_json_dict(self, json_dict: dict, value_tuple: tuple):
-        self._adjust_json_dict_for_param(json_dict, 'time_frequency', 'time_frequencies', value_tuple[0])
-        self._adjust_json_dict_for_param(json_dict, 'processing_level', 'processing_levels', value_tuple[1])
-        self._adjust_json_dict_for_param(json_dict, 'data_type', 'data_types', value_tuple[2])
-        self._adjust_json_dict_for_param(json_dict, 'sensor_id', 'sensor_ids', value_tuple[3])
-        self._adjust_json_dict_for_param(json_dict, 'platform_id', 'platform_ids', value_tuple[4])
-        self._adjust_json_dict_for_param(json_dict, 'product_string', 'product_strings', value_tuple[5])
-        self._adjust_json_dict_for_param(json_dict, 'product_version', 'product_versions', value_tuple[6])
+    def _adjust_json_dict(self, json_dict: dict, drs_id: str):
+        values = drs_id.split('.')
+        self._adjust_json_dict_for_param(json_dict, 'time_frequency', 'time_frequencies',
+                                         self._convert_time_from_drs_id(values[2]))
+        self._adjust_json_dict_for_param(json_dict, 'processing_level', 'processing_levels', values[3])
+        self._adjust_json_dict_for_param(json_dict, 'data_type', 'data_types', values[4])
+        self._adjust_json_dict_for_param(json_dict, 'sensor_id', 'sensor_ids', values[5])
+        self._adjust_json_dict_for_param(json_dict, 'platform_id', 'platform_ids', values[6])
+        self._adjust_json_dict_for_param(json_dict, 'product_string', 'product_strings', values[7])
+        self._adjust_json_dict_for_param(json_dict, 'product_version', 'product_versions', values[8])
+
+    def _convert_time_from_drs_id(self, time_value: str) -> str:
+        if time_value == 'mon' or time_value == 'month':
+            return 'month'
+        if time_value == 'yr' or time_value == 'year':
+            return 'year'
+        if time_value == 'day':
+            return 'day'
+        if time_value == 'satellite-orbit-frequency':
+            return 'satellite-orbit-frequency'
+        if time_value == '5-days':
+            return '5 days'
+        if time_value == '8-days':
+            return '8 days'
+        if time_value == '15-days':
+            return '15 days'
+        if time_value == '13-yrs':
+            return '13 years'
+        if time_value == 'climatology':
+            return 'climatology'
+        raise ValueError('Unknown time frequency format')
 
     def _adjust_json_dict_for_param(self, json_dict: dict, single_name: str, list_name: str, param_value: str):
         json_dict[single_name] = param_value
@@ -807,7 +808,7 @@ class EsaCciOdpDataStore(DataStore):
             return [meta_info[single_name]]
         if list_name in meta_info:
             return meta_info[list_name]
-        return None
+        return []
 
     def _get_update_tag(self):
         """
@@ -941,12 +942,9 @@ class EsaCciOdpDataSource(DataSource):
                  json_dict: dict,
                  raw_datasource_id: str,
                  datasource_id: str,
-                 value_tuple: Tuple,
                  schema: Schema = None):
         super(EsaCciOdpDataSource, self).__init__()
         self._raw_id = raw_datasource_id
-        self._time_frequency, self._processing_level, self._data_type, self._sensor_id, self._platform_id, \
-        self._product_string, self._product_version = value_tuple
         self._datasource_id = datasource_id
         self._data_store = data_store
         self._json_dict = json_dict
@@ -954,6 +952,27 @@ class EsaCciOdpDataSource(DataSource):
         self._file_list = None
         self._meta_info = None
         self._temporal_coverage = None
+
+    def _convert_time_from_drs_id(self, time_value: str) -> str:
+        if time_value == 'mon' or time_value == 'month':
+            return 'month'
+        if time_value == 'yr' or time_value == 'year':
+            return 'year'
+        if time_value == 'day':
+            return 'day'
+        if time_value == 'satellite-orbit-frequency':
+            return 'satellite-orbit-frequency'
+        if time_value == '5-days':
+            return '5 days'
+        if time_value == '8-days':
+            return '8 days'
+        if time_value == '15-days':
+            return '15 days'
+        if time_value == '13-yrs':
+            return '13 years'
+        if time_value == 'climatology':
+            return 'climatology'
+        raise ValueError('Unknown time frequency format')
 
     @property
     def id(self) -> str:
@@ -1351,10 +1370,7 @@ class EsaCciOdpDataSource(DataSource):
         if self._file_list:
             return
         file_list = await _load_or_fetch_json(_fetch_file_list_json,
-                                              fetch_json_args=[self._raw_id, self._time_frequency,
-                                                               self._processing_level, self._data_type,
-                                                               self._sensor_id, self._platform_id,
-                                                               self._product_string, self._product_version],
+                                              fetch_json_args=[self._raw_id, self._datasource_id],
                                               fetch_json_kwargs=dict(monitor=monitor),
                                               cache_used=self._data_store.index_cache_used,
                                               cache_dir=self.local_metadata_dataset_dir(),

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -328,15 +328,15 @@ class OperationCommandTest(CliTestCase):
 class DataSourceCommandTest(CliTestCase):
     def test_ds_info(self):
         self.assert_main(['ds', 'info',
-                          'esacci2.SOILMOISTURE.day.L3S.SSMS.multi-sensor.multi-platform.ACTIVE.04-5.r1'],
+                          'esacci.SOILMOISTURE.day.L3S.SSMS.multi-sensor.multi-platform.ACTIVE.04-5.r1'],
                          expected_status=0,
                          expected_stdout=[
-                             'Data source esacci2.SOILMOISTURE.day.L3S.SSMS.multi-sensor.multi-platform.ACTIVE.04-5.r1'])
+                             'Data source esacci.SOILMOISTURE.day.L3S.SSMS.multi-sensor.multi-platform.ACTIVE.04-5.r1'])
         self.assert_main(['ds', 'info',
-                          'esacci2.SOILMOISTURE.day.L3S.SSMS.multi-sensor.multi-platform.ACTIVE.04-5.r1', '--var'],
+                          'esacci.SOILMOISTURE.day.L3S.SSMS.multi-sensor.multi-platform.ACTIVE.04-5.r1', '--var'],
                          expected_status=0,
                          expected_stdout=[
-                             'Data source esacci2.SOILMOISTURE.day.L3S.SSMS.multi-sensor.multi-platform.ACTIVE.04-5.r1',
+                             'Data source esacci.SOILMOISTURE.day.L3S.SSMS.multi-sensor.multi-platform.ACTIVE.04-5.r1',
                              'dnflag ():'])
         self.assert_main(['ds', 'info', 'SOIL_MOISTURE_DAILY_FILES_ACTIVE_V02.2'],
                          expected_status=1,

--- a/tests/ds/test_esa_cci_odp.py
+++ b/tests/ds/test_esa_cci_odp.py
@@ -319,7 +319,7 @@ class EsaCciOdpDataSourceTest(unittest.TestCase):
 
     def test_make_local_and_update(self):
         soil_moisture_data_sources = self.data_store.query(
-            query_expr='esacci2.SOILMOISTURE.day.L3S.SSMS.multi-sensor.multi-platform.ACTIVE.04-5.r1')
+            query_expr='esacci.SOILMOISTURE.day.L3S.SSMS.multi-sensor.multi-platform.ACTIVE.04-5.r1')
         soilmoisture_data_source = soil_moisture_data_sources[0]
 
         reference_path = os.path.join(os.path.dirname(__file__),
@@ -493,7 +493,7 @@ class EsaCciOdpDataSourceTest(unittest.TestCase):
                       self.data_store)
 
     def test_id(self):
-        self.assertEqual('esacci2.OC.day.L3S.CHLOR_A.multi-sensor.multi-platform.MERGED.3-1.sinusoidal',
+        self.assertEqual('esacci.OC.day.L3S.CHLOR_A.multi-sensor.multi-platform.MERGED.3-1.sinusoidal',
                          self.first_oc_data_source.id)
 
     def test_schema(self):

--- a/tests/ds/test_esa_cci_odp.py
+++ b/tests/ds/test_esa_cci_odp.py
@@ -613,7 +613,7 @@ class DownloadStatisticsTest(unittest.TestCase):
         self.assertEqual(str(download_stats), '64 of 64 MB @ 0.000 MB/s, 100.0% complete')
 
 
-# @unittest.skip(reason='Used for debugging to fix Cate issues #823, #822, #818, #816, #783')
+@unittest.skip(reason='Used for debugging to fix Cate issues #823, #822, #818, #816, #783')
 class SpatialSubsetTest(unittest.TestCase):
 
     @unittest.skip(reason='Requires variable access which is not integrated yet.')
@@ -627,19 +627,3 @@ class SpatialSubsetTest(unittest.TestCase):
         # The following reproduced Cate issues #823, #822, #818, #816, #783:
         ds = data_source.make_local('local_name', time_range=['2004-01-01', '2004-01-14'], region='-10,40,20,70')
         self.assertIsNotNone(ds)
-
-    # def test_time_problem(self):
-        # import xarray as xr
-        # xr.open_dataset(
-        #     'http://cci-odp-data2.ceda.ac.uk/thredds/dodsC/esacci/sst/data/CDR_v2/AVHRR/L3C/v2.1/AVHRR19_G/2009/02/23/20090223120000-ESACCI-L3C_GHRSST-SSTskin-AVHRR19_G-CDR2.1_night-v02.0-fv01.0.nc')
-        #     'http://cci-odp-data2.ceda.ac.uk/thredds/dodsC/esacci/sst/data/CDR_v2/AVHRR/L3C/v2.1/AVHRR19_G/2009/02/23/20090223120000-ESACCI-L3C_GHRSST-SSTskin-AVHRR19_G-CDR2.1_day-v02.0-fv01.0.nc')
-
-        # import cate.core.ds as cate_ds
-        # data_store = EsaCciOdpDataStore()
-        # data_source = data_store.query(ds_id='esacci.SST.day.L3C.SSTskin.AVHRR-3.NOAA-19.AVHRR19_G.2-1.r1')[0]
-        # t_range = (datetime(2009, 2, 23, 12, 0), datetime(2009, 2, 23, 12, 0))
-        # time_range = tuple(t.strftime('%Y-%m-%d') for t in t_range)
-        # ds = data_source.make_local('local_name_4', time_range=time_range)
-        # ds2 = cate_ds.open_dataset(ds)
-        ds = data_source.open_dataset(time_range=time_range, region='-10,40,20,70')
-        # self.assertIsNotNone(ds2)


### PR DESCRIPTION
Use the dsr ids provided by the Open Data Portal to identify data sets. This causes that more datasets are available and others, erroneously included, are removed.