### PR TITLE
Toniof 894 xml error

### DIFF
--- a/cate/ds/esa_cci_odp.py
+++ b/cate/ds/esa_cci_odp.py
@@ -191,10 +191,11 @@ async def _extract_metadata_from_descxml_url(session=None, descxml_url: str = No
         return {}
     resp = await session.request(method='GET', url=descxml_url)
     resp.raise_for_status()
-    descxml = etree.XML(await resp.read())
+    content = await resp.read()
     try:
+        descxml = etree.XML(content)
         return _extract_metadata_from_descxml(descxml)
-    except etree.ParseError:
+    except etree.XMLSyntaxError:
         _LOG.info(f'Cannot read metadata from {descxml_url} due to parsing error.')
         return {}
 

--- a/tests/ds/test_esa_cci_odp.py
+++ b/tests/ds/test_esa_cci_odp.py
@@ -115,6 +115,12 @@ class EsaCciOdpOsTest(unittest.TestCase):
             json_obj = _extract_metadata_from_descxml(XML(desc.read()))
             self.assert_json_obj_from_desc_xml(json_obj)
 
+    def test_extract_metadata_from_descxml_faulty_url(self):
+        desc_url = 'https://catalogue.ceda.ac.uk'
+        json_obj = asyncio.run(_extract_metadata_from_descxml_url(None, desc_url))
+        self.assertIsNotNone(json_obj)
+        self.assertEqual(0, len(json_obj.keys()))
+
     @unittest.skip(reason='Requires web access')
     def test_retrieve_dimensions_from_dds_url(self):
         dds_url = "http://dap.ceda.ac.uk/thredds/dodsC/dap//neodc/esacci/soil_moisture/data/daily_files/" \

--- a/tests/ds/test_esa_cci_odp.py
+++ b/tests/ds/test_esa_cci_odp.py
@@ -116,7 +116,7 @@ class EsaCciOdpOsTest(unittest.TestCase):
             self.assert_json_obj_from_desc_xml(json_obj)
 
     def test_extract_metadata_from_descxml_faulty_url(self):
-        desc_url = 'https://catalogue.ceda.ac.uk'
+        desc_url = 'http://brockmann-consult.de'
         json_obj = asyncio.run(_extract_metadata_from_descxml_url(None, desc_url))
         self.assertIsNotNone(json_obj)
         self.assertEqual(0, len(json_obj.keys()))


### PR DESCRIPTION
Solves #894 . The fix to this issue was two-fold, as the problem was actually that an xml file was missing in the odp. It has been added again and the error cannot be reproduced anymore.
Anyhow, the fix in this PR will ensure that if anything similar should happen in the future, the affected data source will be skipped and all others will be read in, so that the data store can still be used.