### PR TITLE
Support zonal mean data

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ## Version 2.1.0 (in development)
-
+* Added normalization method in order to handle datasets with zonal means 
+  which have no longitude information.
 * Remodeled ODP Data Store to support newly designed CEDA OpenSearch Service. 
   The previous Data Store implementation is now available as "ESA CCI Open Data Portal Legacy".   
 * Cate Web API at now allows changes to the root path using environment variable JUPYTERHUB_SERVICE_PREFIX. This is relevant to Catehub context where each user's cate service is mounted on /user/{username}/{cate-web-api-endpoint}.

--- a/cate/core/opimpl.py
+++ b/cate/core/opimpl.py
@@ -60,6 +60,7 @@ def normalize_impl(ds: xr.Dataset) -> xr.Dataset:
     :param ds: The dataset to normalize.
     :return: The normalized dataset, or the original dataset, if it is already "normal".
     """
+    ds = _normalize_zonal_lat_lon(ds)
     ds = normalize_coord_vars(ds)
     ds = _normalize_lat_lon(ds)
     ds = _normalize_lat_lon_2d(ds)
@@ -69,6 +70,59 @@ def normalize_impl(ds: xr.Dataset) -> xr.Dataset:
     ds = normalize_missing_time(ds)
     ds = _normalize_jd2datetime(ds)
     return ds
+
+
+def _normalize_zonal_lat_lon(ds: xr.Dataset) -> xr.Dataset:
+    """
+    In case that the dataset only contains lat_centers and is a zonal mean dataset,
+    a lon dimension is filled with the value of a certain latitude.
+    :param ds: some xarray dataset
+    :return: a normalized xarray dataset
+    """
+
+    if 'latitude_centers' not in ds.coords:
+        return ds
+
+    ds_zonal = ds.copy()
+    resolution = (ds.latitude_centers.values[1] - ds.latitude_centers.values[0])
+    ds_zonal = ds_zonal.assign_coords(lon=[i + (resolution / 2) for i in np.arange(-180.0, 180.0, resolution)])
+
+
+    for var in ds_zonal.variables:
+        if var not in ds_zonal.coords:
+            if sorted([dim for dim in ds_zonal[var].dims]) == sorted([coord for coord in ds.coords]):
+                ds_zonal[var] = xr.concat([ds_zonal[var] for _ in ds_zonal.lon], 'lon')
+                ds_zonal[var]['lon'] = ds_zonal.lon
+    ds_zonal = ds_zonal.assign_coords(lat=ds.latitude_centers.values)
+    ds_zonal = ds_zonal.rename_dims({'latitude_centers': 'lat'})
+    ds_zonal = ds_zonal.drop('latitude_centers')
+    ds_zonal = ds_zonal.transpose(..., 'lat', 'lon')
+
+    has_lon_bnds = 'lon_bnds' in ds_zonal.coords or 'lon_bnds' in ds_zonal
+    if not has_lon_bnds:
+        ds_zonal = ds_zonal.assign_coords(
+            lon_bnds=xr.DataArray([[i - (resolution / 2), i + (resolution / 2)] for i in ds_zonal.lon.values],
+                                  dims=['lon', 'bnds']))
+    has_lat_bnds = 'lat_bnds' in ds_zonal.coords or 'lat_bnds' in ds_zonal
+    if not has_lat_bnds:
+        ds_zonal = ds_zonal.assign_coords(
+            lat_bnds=xr.DataArray([[i - (resolution / 2), i + (resolution / 2)] for i in ds_zonal.lat.values],
+                                  dims=['lat', 'bnds']))
+
+    ds_zonal.lon.attrs['bounds'] = 'lon_bnds'
+    ds_zonal.lon.attrs['long_name'] = 'longitude'
+    ds_zonal.lon.attrs['standard_name'] = 'longitude'
+    ds_zonal.lon.attrs['units'] = 'degrees_east'
+
+    ds_zonal.lat.attrs['bounds'] = 'lat_bnds'
+    ds_zonal.lat.attrs['long_name'] = 'latitude'
+    ds_zonal.lat.attrs['standard_name'] = 'latitude'
+    ds_zonal.lat.attrs['units'] = 'degrees_north'
+
+
+
+    # ds = ds_zonal.copy()
+    return ds_zonal
 
 
 def _normalize_inverted_lat(ds: xr.Dataset) -> xr.Dataset:
@@ -784,7 +838,7 @@ def reset_non_spatial(ds_source: xr.Dataset, ds_target: xr.Dataset):
     non_spatial = list()
     for var_name in ds_source.data_vars.keys():
         if 'lat' not in ds_source[var_name].dims and \
-           'lon' not in ds_source[var_name].dims:
+                'lon' not in ds_source[var_name].dims:
             non_spatial.append(var_name)
 
     retset = ds_target
@@ -1067,7 +1121,6 @@ def subset_temporal_index_impl(ds: xr.Dataset,
 
 
 def _normalize_dim_order(ds: xr.Dataset) -> xr.Dataset:
-
     copy_created = False
 
     for var_name in ds.data_vars:

--- a/cate/core/opimpl.py
+++ b/cate/core/opimpl.py
@@ -75,18 +75,18 @@ def normalize_impl(ds: xr.Dataset) -> xr.Dataset:
 def _normalize_zonal_lat_lon(ds: xr.Dataset) -> xr.Dataset:
     """
     In case that the dataset only contains lat_centers and is a zonal mean dataset,
-    a lon dimension is filled with the value of a certain latitude.
+    the longitude dimension created and filled with the variable value of certain latitude.
     :param ds: some xarray dataset
     :return: a normalized xarray dataset
     """
 
     if 'latitude_centers' not in ds.coords:
         return ds
-
+    if 'lon' in ds.coords:
+        return ds
     ds_zonal = ds.copy()
     resolution = (ds.latitude_centers.values[1] - ds.latitude_centers.values[0])
     ds_zonal = ds_zonal.assign_coords(lon=[i + (resolution / 2) for i in np.arange(-180.0, 180.0, resolution)])
-
 
     for var in ds_zonal.variables:
         if var not in ds_zonal.coords:
@@ -119,10 +119,8 @@ def _normalize_zonal_lat_lon(ds: xr.Dataset) -> xr.Dataset:
     ds_zonal.lat.attrs['standard_name'] = 'latitude'
     ds_zonal.lat.attrs['units'] = 'degrees_north'
 
-
-
-    # ds = ds_zonal.copy()
-    return ds_zonal
+    ds = ds_zonal.copy()
+    return ds
 
 
 def _normalize_inverted_lat(ds: xr.Dataset) -> xr.Dataset:

--- a/tests/ops/test_normalize.py
+++ b/tests/ops/test_normalize.py
@@ -27,6 +27,22 @@ def assertDatasetEqual(expected, actual):
 
 
 class TestNormalize(TestCase):
+    def test_normalize_zonal_lat_lon(self):
+        lat_size = 3
+        lat_coords = np.arange(0, 30, 10)
+        var_values_1d = xr.DataArray(np.random.random(lat_size), coords=[('latitude_centers', lat_coords)])
+
+        lon_coords = [i + 5. for i in np.arange(-180.0, 180.0, 10.)]
+
+        var_values_2d = xr.DataArray(np.array([var_values_1d.values for _ in lon_coords]).T,
+                                     coords={'lat': lat_coords, 'lon': lon_coords},
+                                     dims=['lat', 'lon'])
+        dataset = xr.Dataset({'first': var_values_1d})
+        expected = xr.Dataset({'first': var_values_2d})
+        actual = normalize(dataset)
+
+        xr.testing.assert_equal(actual, expected)
+
     def test_normalize_lon_lat_2d(self):
         """
         Test nominal execution


### PR DESCRIPTION
This PR is related to issue #902 .
Cate now creates a longitude dimension for datasets which have zonal means, latitude center and no longitude information. 