### PR TITLE
Fixing saving partial preferences

### DIFF
--- a/cate/conf/userprefs.py
+++ b/cate/conf/userprefs.py
@@ -107,10 +107,12 @@ def set_user_prefs(prefs: dict, user_prefs_file: str = None):
 
     if not os.path.isfile(user_prefs_file):
         _write_user_prefs_file(user_prefs_file, _DEFAULT_USER_PREFS)
+    else:
+        _prefs = get_user_prefs(user_prefs_file)
+        _prefs.update(prefs)
+        _write_user_prefs_file(user_prefs_file, _prefs)
 
-    _write_user_prefs_file(user_prefs_file, prefs)
-
-    return get_user_prefs()
+    return get_user_prefs(user_prefs_file)
 
 
 def get_user_prefs(user_prefs_file: str = None) -> dict:

--- a/cate/webapi/start.py
+++ b/cate/webapi/start.py
@@ -84,28 +84,6 @@ class WebAPIInfoHandler(WebAPIRequestHandler):
         self.finish()
 
 
-# noinspection PyAbstractClass
-class WebAPICfgHandler(WebAPIRequestHandler):
-    def get(self):
-        user_root_mode = isinstance(self.application.workspace_manager, RelativeFSWorkspaceManager)
-
-        self.write_status_ok(content={'name': SERVICE_NAME,
-                                      'version': __version__,
-                                      'timestaffmp': date.today().isoformat(),
-                                      'user_root_mode': user_root_mode})
-
-        self.finish()
-
-    def post(self):
-        pass
-
-    def put(self):
-        pass
-
-    def delete(self):
-        pass
-
-
 def service_factory(application):
     return WebSocketService(application.workspace_manager)
 
@@ -132,7 +110,6 @@ def create_application(user_root_path: str = None):
         (url_pattern(url_root + 'mpl/download/{{base_dir}}/{{figure_id}}/{{format_name}}'), MplDownloadHandler),
         (url_pattern(url_root + 'mpl/figures/{{base_dir}}/{{figure_id}}'), MplWebSocketHandler),
         (url_pattern(url_root), WebAPIInfoHandler),
-        (url_pattern(url_root + 'cfg'), WebAPICfgHandler),
         (url_pattern(url_root + 'exit'), WebAPIExitHandler),
         (url_pattern(url_root + 'api'), JsonRpcWebSocketHandler, dict(
             service_factory=service_factory,

--- a/tests/conf/test_userprefs.py
+++ b/tests/conf/test_userprefs.py
@@ -92,6 +92,7 @@ class MyTestCase(unittest.TestCase):
         self.assertDictEqual(n_prefs, prefs)
 
     def test_set_user_prefs(self):
+        self.maxDiff = None
         tdir = tempfile.gettempdir()
         tfile = os.path.join(tdir, 'test_set_prefs.txt')
         prefs = set_user_prefs(_TEST_USER_PREFS, tfile)
@@ -102,6 +103,13 @@ class MyTestCase(unittest.TestCase):
         n_prefs['autoUpdateSoftware'] = True
 
         prefs = set_user_prefs(n_prefs)
+
+        self.assertDictEqual(n_prefs, prefs)
+
+        n_prefs = _TEST_USER_PREFS.copy()
+        n_prefs['autoUpdateSoftware'] = True
+
+        prefs = set_user_prefs({'autoUpdateSoftware': True})
 
         self.assertDictEqual(n_prefs, prefs)
 

--- a/tests/ops/test_io.py
+++ b/tests/ops/test_io.py
@@ -75,11 +75,11 @@ class TestIO(TestCase):
 
     def test_read_geo_data_frame(self):
         file = os.path.join(os.path.dirname(__file__), '..', '..', 'cate', 'ds', 'data', 'countries',
-                            'countries.geojson')
+                            'countries-110m.geojson')
 
         data_frame = read_geo_data_frame(file=file)
         self.assertIsInstance(data_frame, gpd.GeoDataFrame)
-        self.assertEqual(len(data_frame), 179)
+        self.assertEqual(len(data_frame), 175)
         data_frame.close()
 
     def test_write_geo_data_frame(self):

--- a/tests/webapi/test_geojson.py
+++ b/tests/webapi/test_geojson.py
@@ -176,14 +176,14 @@ class WriteFeatureCollectionTest(TestCase):
             pass
 
         file = os.path.join(os.path.dirname(__file__), '..', '..', 'cate', 'ds', 'data', 'countries',
-                            'countries.geojson')
+                            'countries-110m.geojson')
 
         collection = fiona.open(file)
 
         from io import StringIO
         string_io = StringIO()
         num_written = write_feature_collection(collection, string_io, conservation_ratio=0)
-        self.assertEqual(num_written, 179)
+        self.assertEqual(num_written, 175)
 
 
 class SimplifyGeometryTest(TestCase):


### PR DESCRIPTION
When accepting this PR cate will save the preferences correctly when only part of
the preference dictionary is sent by a client.
