### PR TITLE
Fix "animate map" bugs

### DIFF
--- a/cate/ops/animate.py
+++ b/cate/ops/animate.py
@@ -55,6 +55,8 @@ import os
 # except Exception:
 #     has_qt5agg = False
 
+import matplotlib
+matplotlib.use("Agg")
 import matplotlib.animation as animation
 import matplotlib.pyplot as plt
 

--- a/environment.yml
+++ b/environment.yml
@@ -22,7 +22,8 @@ dependencies:
   - hdf5>=1.10.4
   - jdcal>=1.4.1
   - lxml>=4.5
-  - matplotlib-base>=3.1.3
+  # Workaround to avoid cartopy 0.17.0 / matplotlib 3.3.0 conflict (Issue #927)
+  - matplotlib-base>=3.1.3,<3.3.0
   - numba>=0.48.0
   - numpy>=1.18.1
   - netcdf4>=1.5.1.2


### PR DESCRIPTION
This PR fixes two bugs which prevented "animate map" from working correctly in the Web 

Fixes #926. Fixes #927.