### PR TITLE
cate-937: ODP Store keeps producing 500 Errors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 ## Version 2.1.1 (in development)
 
-* Prevent 500 Errors when using the ODP Data Store. #937
+* Prevent HTTP 500 errors when using the ODP Data Store. #937
 * Fixed a problem that prevented opening GeoJSON files
   in a workspace. #933
 * Fixed a problem that prevented reopening workspaces using 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ## Version 2.1.1 (in development)
 
+* Prevent 500 Errors when using the ODP Data Store. #937
 * Fixed a problem that prevented opening GeoJSON files
   in a workspace. #933
 * Fixed a problem that prevented reopening workspaces using 


### PR DESCRIPTION
Solves #937 . If a 500 error is encountered, it will simply be tried again to access the website, up to 200 times. If the error still exists then, the code will not crash but simply deal with that it gets no result.