### PR TITLE
hardcoded omitting duplicate ds ids

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 ## Version 2.1.1
 
+* Fixed issue with duplicate dataset ids: Sometimes a drs_id contains more than one feature and therefore is associated 
+  with more than one datasource_id.
+  This is an error on ODP and is not handled by cate correctly. To prohibit problems, it is manually checked,
+  which feature contains less datasets and is dropped in favor of the feature with more datasets by using 
+  cate.ds.esa_cci_odp.EsaCciOdpDataStore.is_dataset_dropped
 * Prevent HTTP 500 errors when using the ODP Data Store. #937
 * Spatial points are now parsed from CSV files when using the `read_csv()`operation.
   This is an option which can be disabled. #935

--- a/cate/ds/esa_cci_odp.py
+++ b/cate/ds/esa_cci_odp.py
@@ -790,15 +790,7 @@ class EsaCciOdpDataStore(DataStore):
         for drs_id in drs_ids:
             if drs_id not in self._drs_ids:
                 continue
-            # todo remove as soon as the double occurrence of the drs id is removed from the odp
-            if drs_id == 'esacci.AEROSOL.satellite-orbit-frequency.L2P.AER_PRODUCTS.ATSR-2.ERS-2.SU.4-21.r1' and \
-                    datasource_id == '59f3a38819e140b49ffe46f32176709e':
-                continue
-            if drs_id == 'esacci.AEROSOL.day.L3C.AER_PRODUCTS.ATSR-2.Envisat.ATSR2.v2-6.r1' and \
-                    datasource_id == 'c183044b88734442b6d37f5c4f6b0092':
-                continue
-            if drs_id == 'esacci.AEROSOL.satellite-orbit-frequency.L2P.AER_PRODUCTS.AATSR.Envisat.AATSR-ENVISAT-ENS.v2-6.r1' and \
-                    datasource_id == '4afb736dc395442aa9b327c11f0d704b':
+            if self.is_dataset_dropped(drs_id, datasource_id):
                 continue
             meta_info = meta_info.copy()
             meta_info.update(json_dict)
@@ -949,6 +941,27 @@ class EsaCciOdpDataStore(DataStore):
                                                     cache_timestamp_filename='dataset-list-timestamp.json',
                                                     cache_expiration_days=self._index_cache_expiration_days
                                                     )
+
+    def is_dataset_dropped(self, drs_id, datasource_id):
+        # todo remove as soon as the double occurrence of the drs id is removed from the odp
+        """
+        Sometimes a drs_id contains more than one feature and therefore is associated with more than one datasource_id.
+        This is an error on ODP and is not handled by cate correctly. To prohibit problems, it is manually checked,
+        which feature contains less datasets and is dropped in favor of the feature with more datasets.
+        :return:
+        """
+        to_be_dropped = [('esacci.AEROSOL.satellite-orbit-frequency.L2P.AER_PRODUCTS.ATSR-2.ERS-2.SU.4-21.r1',
+                          '59f3a38819e140b49ffe46f32176709e'),
+                         ('esacci.AEROSOL.day.L3C.AER_PRODUCTS.ATSR-2.Envisat.ATSR2.v2-6.r1',
+                          'c183044b88734442b6d37f5c4f6b0092'),
+                         (
+                             'esacci.AEROSOL.satellite-orbit-frequency.L2P.AER_PRODUCTS.AATSR.Envisat.AATSR-ENVISAT-ENS.v2-6.r1',
+                             '4afb736dc395442aa9b327c11f0d704b')
+                         ]
+        if (drs_id, datasource_id) in to_be_dropped:
+            return True
+        else:
+            return False
 
 
 INFO_FIELD_NAMES = sorted(["title",

--- a/cate/ds/esa_cci_odp.py
+++ b/cate/ds/esa_cci_odp.py
@@ -602,7 +602,7 @@ class EsaCciOdpDataStore(DataStore):
                  index_cache_json_dict: dict = None,
                  index_cache_update_tag: str = None,
                  meta_data_store_path: str = get_metadata_store_path(),
-                 drs_ids:List[str] = None
+                 drs_ids: List[str] = None
                  ):
         super().__init__(id, title=title, is_local=False)
         if drs_ids is None:
@@ -793,6 +793,12 @@ class EsaCciOdpDataStore(DataStore):
             # todo remove as soon as the double occurrence of the drs id is removed from the odp
             if drs_id == 'esacci.AEROSOL.satellite-orbit-frequency.L2P.AER_PRODUCTS.ATSR-2.ERS-2.SU.4-21.r1' and \
                     datasource_id == '59f3a38819e140b49ffe46f32176709e':
+                continue
+            if drs_id == 'esacci.AEROSOL.day.L3C.AER_PRODUCTS.ATSR-2.Envisat.ATSR2.v2-6.r1' and \
+                    datasource_id == 'c183044b88734442b6d37f5c4f6b0092':
+                continue
+            if drs_id == 'esacci.AEROSOL.satellite-orbit-frequency.L2P.AER_PRODUCTS.AATSR.Envisat.AATSR-ENVISAT-ENS.v2-6.r1' and \
+                    datasource_id == '4afb736dc395442aa9b327c11f0d704b':
                 continue
             meta_info = meta_info.copy()
             meta_info.update(json_dict)

--- a/tests/ds/test_esa_cci_odp.py
+++ b/tests/ds/test_esa_cci_odp.py
@@ -658,6 +658,7 @@ class MakeLocalTest(unittest.TestCase):
         local_data_store.remove_data_source(f"local.{random_string}")
 
 
+@unittest.skip(reason='Used for debugging issue with duplicate dsr_ids')
 class NoDuplicatesTest(unittest.TestCase):
     def test_for_duplicates_in_drs_ids(self):
         data_store = EsaCciOdpDataStore()

--- a/tests/ds/test_esa_cci_odp.py
+++ b/tests/ds/test_esa_cci_odp.py
@@ -656,3 +656,17 @@ class MakeLocalTest(unittest.TestCase):
         ds = data_source.make_local(random_string)
         self.assertIsNotNone(ds)
         local_data_store.remove_data_source(f"local.{random_string}")
+
+
+class NoDuplicatesTest(unittest.TestCase):
+    def test_for_duplicates_in_drs_ids(self):
+        data_store = EsaCciOdpDataStore()
+        data_sets = data_store.query()
+        ids = []
+        for dataset in data_sets:
+            ids.append(dataset.id)
+        if len(ids) == len(set(ids)):
+            contains_duplicates = False
+        else:
+            contains_duplicates = True
+        self.assertFalse(contains_duplicates)


### PR DESCRIPTION
hard coded omitting feature id 
'c183044b88734442b6d37f5c4f6b0092' for  drs_id 'esacci.AEROSOL.day.L3C.AER_PRODUCTS.ATSR-2.Envisat.ATSR2.v2-6.r1' 
as well as feature id '4afb736dc395442aa9b327c11f0d704b' for  'esacci.AEROSOL.satellite-orbit-frequency.L2P.AER_PRODUCTS.AATSR.Envisat.AATSR-ENVISAT-ENS.v2-6.r1' 