### PR TITLE
fix of weirdo string is not a list issue (duh!) #949

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 * Added package `s3fs` to Python environment as it is required to open Zarr datasets 
   from S3-compatible object store. #940
+* Fixed issue of harmonization of info field names of metadata (#949)
 
 ## Version 2.1.1
 

--- a/cate/ds/esa_cci_odp.py
+++ b/cate/ds/esa_cci_odp.py
@@ -374,6 +374,8 @@ def _harmonize_info_field_names(catalogue: dict, single_field_name: str, multipl
         else:
             if catalogue[single_field_name] not in catalogue[multiple_fields_name] \
                     and (multiple_items_name is None or catalogue[single_field_name] != multiple_items_name):
+                if type(catalogue[multiple_fields_name]) != list:
+                    catalogue[multiple_fields_name] = [catalogue[multiple_fields_name]]
                 catalogue[multiple_fields_name].append(catalogue[single_field_name])
             catalogue.pop(single_field_name)
 

--- a/cate/ds/esa_cci_odp.py
+++ b/cate/ds/esa_cci_odp.py
@@ -374,7 +374,7 @@ def _harmonize_info_field_names(catalogue: dict, single_field_name: str, multipl
         else:
             if catalogue[single_field_name] not in catalogue[multiple_fields_name] \
                     and (multiple_items_name is None or catalogue[single_field_name] != multiple_items_name):
-                if type(catalogue[multiple_fields_name]) != list:
+                if not instanceof(catalogue[multiple_fields_name], list):
                     catalogue[multiple_fields_name] = [catalogue[multiple_fields_name]]
                 catalogue[multiple_fields_name].append(catalogue[single_field_name])
             catalogue.pop(single_field_name)

--- a/cate/ds/esa_cci_odp.py
+++ b/cate/ds/esa_cci_odp.py
@@ -374,7 +374,7 @@ def _harmonize_info_field_names(catalogue: dict, single_field_name: str, multipl
         else:
             if catalogue[single_field_name] not in catalogue[multiple_fields_name] \
                     and (multiple_items_name is None or catalogue[single_field_name] != multiple_items_name):
-                if not instanceof(catalogue[multiple_fields_name], list):
+                if not isinstance(catalogue[multiple_fields_name], list):
                     catalogue[multiple_fields_name] = [catalogue[multiple_fields_name]]
                 catalogue[multiple_fields_name].append(catalogue[single_field_name])
             catalogue.pop(single_field_name)

--- a/tests/ds/test_esa_cci_odp.py
+++ b/tests/ds/test_esa_cci_odp.py
@@ -658,7 +658,7 @@ class MakeLocalTest(unittest.TestCase):
         local_data_store.remove_data_source(f"local.{random_string}")
 
 
-@unittest.skip(reason='Used for debugging issue with duplicate dsr_ids')
+@unittest.skip(reason='Used for debugging issue with duplicate dsr_ids and weirdo bug #949')
 class NoDuplicatesTest(unittest.TestCase):
     def test_for_duplicates_in_drs_ids(self):
         data_store = EsaCciOdpDataStore()


### PR DESCRIPTION
For some datasets (AEROSOL, 9 datasets) the harmonization of metadata failed due to one attribute not being an expected list but a string. This is now fixed by ensuring, that in case it is not a list, it is converted into one. 