### PR TITLE
Alicja 956 normalize time called t

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,5 @@
 ## Version 2.1.4 (in development)
-* Included normalization of time in case it is called 't' in a dataset instead of 'time' (#956). 
+* Included normalization of a dataset's time coordinate variable in case it is called 't' instead of 'time' (#956). 
   This is the case for the following datasets: 
     * esacci.ICESHEETS.yr.Unspecified.GMB.GRACE-instrument.GRACE.UNSPECIFIED.1-2.greenland_gmb_mass_trends
     * esacci.ICESHEETS.yr.Unspecified.GMB.GRACE-instrument.GRACE.UNSPECIFIED.1-3.greenland_gmb_mass_trends

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,10 +1,6 @@
 ## Version 2.1.4 (in development)
 * Included normalization of a dataset's time coordinate variable in case it is called 't' instead of 'time' (#956). 
-  This is the case for the following datasets: 
-    * esacci.ICESHEETS.yr.Unspecified.GMB.GRACE-instrument.GRACE.UNSPECIFIED.1-2.greenland_gmb_mass_trends
-    * esacci.ICESHEETS.yr.Unspecified.GMB.GRACE-instrument.GRACE.UNSPECIFIED.1-3.greenland_gmb_mass_trends
-    * esacci.ICESHEETS.yr.Unspecified.GMB.GRACE-instrument.GRACE.UNSPECIFIED.1-5.greenland_gmb_mass_trends
-   This is the case for all datasets with IDs `esacci.ICESHEETS.yr.Unspecified.GMB.GRACE-instrument.GRACE.UNSPECIFIED.1-*.greenland_gmb_mass_trends`.
+  This is the case for all datasets with IDs `esacci.ICESHEETS.yr.Unspecified.GMB.GRACE-instrument.GRACE.UNSPECIFIED.1-*.greenland_gmb_mass_trends`.
   
   
 ## Version 2.1.3

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
     * esacci.ICESHEETS.yr.Unspecified.GMB.GRACE-instrument.GRACE.UNSPECIFIED.1-2.greenland_gmb_mass_trends
     * esacci.ICESHEETS.yr.Unspecified.GMB.GRACE-instrument.GRACE.UNSPECIFIED.1-3.greenland_gmb_mass_trends
     * esacci.ICESHEETS.yr.Unspecified.GMB.GRACE-instrument.GRACE.UNSPECIFIED.1-5.greenland_gmb_mass_trends
-    * esacci.ICESHEETS.yr.Unspecified.GMB.GRACE-instrument.GRACE.UNSPECIFIED.1-4.greenland_gmb_mass_trends 
+   This is the case for all datasets with IDs `esacci.ICESHEETS.yr.Unspecified.GMB.GRACE-instrument.GRACE.UNSPECIFIED.1-*.greenland_gmb_mass_trends`.
   
   
 ## Version 2.1.3

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 ## Version 2.1.4 (in development)
-
+* Included normalization of time in case it is called 't' in a dataset instead of 'time' (#956). 
+  This is the case for the following datasets: 
+    * esacci.ICESHEETS.yr.Unspecified.GMB.GRACE-instrument.GRACE.UNSPECIFIED.1-2.greenland_gmb_mass_trends
+    * esacci.ICESHEETS.yr.Unspecified.GMB.GRACE-instrument.GRACE.UNSPECIFIED.1-3.greenland_gmb_mass_trends
+    * esacci.ICESHEETS.yr.Unspecified.GMB.GRACE-instrument.GRACE.UNSPECIFIED.1-5.greenland_gmb_mass_trends
+    * esacci.ICESHEETS.yr.Unspecified.GMB.GRACE-instrument.GRACE.UNSPECIFIED.1-4.greenland_gmb_mass_trends 
+  
+  
 ## Version 2.1.3
 
 * Changed CCI ODP url from test service to production service (archive.opensearch.ceda.ac.uk) (#951)
@@ -13,7 +20,7 @@
   from S3-compatible object store when using the `read_zarr()` operation. (#940)
 * Fixed issue of harmonization of info field names of metadata (#949)
 * Fixed problem with unsupported time format for permafrost datasets below. They have a time_coverage_start and 
-time_coverage_end with a datetime format of 15 characters (#944):
+  time_coverage_end with a datetime format of 15 characters (#944):
     * esacci.PERMAFROST.yr.L4.ALT.multi-sensor.multi-platform.MODIS.01-0.r1
     * esacci.PERMAFROST.yr.L4.GTD.multi-sensor.multi-platform.MODIS.01-0.r1
     * esacci.PERMAFROST.yr.L4.PFR.multi-sensor.multi-platform.MODIS.01-0.r1   

--- a/cate/core/opimpl.py
+++ b/cate/core/opimpl.py
@@ -371,6 +371,8 @@ def normalize_missing_time(ds: xr.Dataset) -> xr.Dataset:
     if either temporal CF attributes ``time_coverage_start`` and ``time_coverage_end``
     are given or time information can be extracted from the file name but the time dimension is missing.
 
+    In case the time information is given by a variable called 't' instead of 'time', it will be renamed into 'time'.
+
     The new time coordinate variable will be named ``time`` with dimension ['time'] and shape [1].
     The time bounds coordinates variable will be named ``time_bnds`` with dimensions ['time', 'bnds'] and shape [1,2].
     Both are of data type ``datetime64``.

--- a/cate/core/opimpl.py
+++ b/cate/core/opimpl.py
@@ -383,9 +383,16 @@ def normalize_missing_time(ds: xr.Dataset) -> xr.Dataset:
     if not time_coverage_start and not time_coverage_end:
         # Can't do anything
         return ds
-
+    time = None
     if 'time' in ds:
-        time = ds.time
+        if isinstance(ds.time.values[0], datetime) or isinstance(ds.time.values[0], np.datetime64):
+            time = ds.time
+    elif 't' in ds:
+        if isinstance(ds.t.values[0], datetime) or isinstance(ds.t.values[0], np.datetime64):
+            ds = ds.rename_vars({"t": "time"})
+            ds = ds.assign_coords(time=('time', ds.time))
+            time = ds.time
+    if time is not None:
         if not time.dims:
             ds = ds.drop_vars('time')
         elif len(time.dims) == 1:

--- a/tests/ds/test_esa_cci_odp.py
+++ b/tests/ds/test_esa_cci_odp.py
@@ -691,3 +691,12 @@ class UnsupportedOperandTypeTest(unittest.TestCase):
         data_source = data_store.query(cci_dataset_collection)[0]
         ds = data_source.open_dataset(time_range=['2010-01-01', '2011-01-30'], var_names=['ALT'])
         self.assertIsNotNone(ds)
+
+@unittest.skip(reason='Used for debugging to fix Cate issue #956 - this test fails, but due to new problem')
+class TasVarnameForTimeTest(unittest.TestCase):
+    def test_normalization_of_time(self):
+        data_store = EsaCciOdpDataStore()
+        cci_dataset_collection = 'esacci.ICESHEETS.yr.Unspecified.GMB.GRACE-instrument.GRACE.UNSPECIFIED.1-2.greenland_gmb_mass_trends'
+        data_source = data_store.query(cci_dataset_collection)[0]
+        ds = data_source.open_dataset(time_range=['2005-07-02', '2005-07-02'], var_names=['GMB_trend'])
+        self.assertIsNotNone(ds)

--- a/tests/ops/test_normalize.py
+++ b/tests/ops/test_normalize.py
@@ -176,6 +176,28 @@ class TestNormalize(TestCase):
         self.assertEqual(norm_ds.coords['time_bnds'][0][0], xr.DataArray(pd.to_datetime('2012-01-01')))
         self.assertEqual(norm_ds.coords['time_bnds'][0][1], xr.DataArray(pd.to_datetime('2012-12-31')))
 
+    def test_normalize_with_time_called_t(self):
+        ds = xr.Dataset({'first': (['time', 'lat', 'lon'], np.zeros([4, 90, 180])),
+                         'second': (['time', 'lat', 'lon'], np.zeros([4, 90, 180])),
+                         't': ('time', np.array(['2005-07-02T00:00:00.000000000',
+                                                 '2006-07-02T12:00:00.000000000',
+                                                 '2007-07-03T00:00:00.000000000',
+                                                 '2008-07-02T00:00:00.000000000'], dtype='datetime64[ns]'))},
+                        coords={'lat': np.linspace(-89.5, 89.5, 90),
+                                'lon': np.linspace(-179.5, 179.5, 180)},
+                        attrs={'time_coverage_start': '2005-01-17',
+                               'time_coverage_end': '2008-08-17'})
+        norm_ds = normalize(ds)
+        self.assertIsNot(norm_ds, ds)
+        self.assertEqual(len(norm_ds.coords), 3)
+        self.assertIn('lon', norm_ds.coords)
+        self.assertIn('lat', norm_ds.coords)
+        self.assertIn('time', norm_ds.coords)
+
+        self.assertEqual(norm_ds.first.shape, (4, 90, 180))
+        self.assertEqual(norm_ds.second.shape, (4, 90, 180))
+        self.assertEqual(norm_ds.coords['time'][0], xr.DataArray(pd.to_datetime('2005-07-02T00:00')))
+
     def test_normalize_julian_day(self):
         """
         Test Julian Day -> Datetime conversion


### PR DESCRIPTION
This PR retrieves the time stamps form a dataset in case they are given via the variable 't' instead of 'time'. Before doing so, it checks, whether the values of 't' are in a datetime format or not. This addresses issue #956. 

