### PR TITLE
Included missing  "aiofiles" and "s3fs" to mock imports in conf.py for rtd

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -26,7 +26,7 @@ from cate.version import __version__ as cate_version
 # http://blog.rtwilson.com/how-to-make-your-sphinx-documentation-compile-with-readthedocs-when-youre-using-numpy-and-scipy/
 import mock
 
-#MOCK_MODULES = ['geopandas', 'cartopy', 'cartopy.crs', 'fiona', 'numba', 'pandas',
+# MOCK_MODULES = ['geopandas', 'cartopy', 'cartopy.crs', 'fiona', 'numba', 'pandas',
 #                'matplotlib', 'matplotlib.animation', 'matplotlib.cm', 'matplotlib.figure', 'matplotlib.pyplot',
 #                'matplotlib.backends.backend_webagg_core',
 #                'pyproj', 'scipy', 'scipy.stats', 'scipy.special',
@@ -35,11 +35,27 @@ import mock
 #                'dask', 'dask.callbacks',
 #                'numpy', 'jdcal', 'dateutil', 'owslib', 'owslib.csw', 'owslib.namespaces', 'psutil']
 
-#for mod_name in MOCK_MODULES:
+# for mod_name in MOCK_MODULES:
 #    sys.modules[mod_name] = mock.Mock()
 
-autodoc_mock_imports = ["xarray", "pandas", "geopandas", "cartopy", "fiona", "numba", "shapely", "jdcal",
-                        "matplotlib", "tornado", "dateutil", "scipy", "owslib", "dask", "psutil" , "pyproj" ]
+autodoc_mock_imports = ['aiofiles',
+                        'cartopy',
+                        'dask',
+                        'dateutil',
+                        'fiona',
+                        'geopandas',
+                        'jdcal',
+                        'matplotlib',
+                        'numba',
+                        'owslib',
+                        'pandas',
+                        'psutil',
+                        'pyproj',
+                        's3fs',
+                        'scipy',
+                        'shapely',
+                        'tornado',
+                        'xarray']
 
 # -- General configuration ------------------------------------------------
 
@@ -254,6 +270,7 @@ html_static_path = ['_static']
 # Output file base name for HTML help builder.
 htmlhelp_basename = software_name + '-doc'
 
+
 # fix to prevent tables from horizontal scrolling. Taken from:
 # https://github.com/snide/sphinx_rtd_theme/issues/117#issuecomment-153083280
 
@@ -261,6 +278,7 @@ htmlhelp_basename = software_name + '-doc'
 def setup(app):
     # overrides for wide tables in RTD theme
     app.add_stylesheet('theme_overrides.css')
+
 
 # -- Options for LaTeX output ---------------------------------------------
 


### PR DESCRIPTION
Read the docs was not compiling all  doc strings due to missing imports within the autodoc_mock_imports of conf.py 
I have added the missing modules and sorted the existing list alphabetically - so only "aiofiles" and "s3fs" have been added, the others just sorted. I checked the docs build of this branch within read the docs : https://cate.readthedocs.io/en/alicja-xxx-fix-rtd/api_reference.html#operations
before it looked like this: 
![image](https://user-images.githubusercontent.com/23457217/98088549-dd755200-1e81-11eb-94a0-f9f9aae13102.png)

Now the Doc strings are fully included. 