### PR TITLE
Apply region constraints before normalizing the time dimension

### DIFF
--- a/cate/core/ds.py
+++ b/cate/core/ds.py
@@ -784,10 +784,12 @@ def open_xarray_dataset(paths,
     if var_names:
         ds = ds.drop_vars([var_name for var_name in ds.data_vars.keys() if var_name not in var_names])
 
-    ds = normalize_impl(ds)
-
     if region:
         ds = subset_spatial_impl(ds, region)
+    
+
+    ds = normalize_impl(ds)
+
 
     return ds
 

--- a/cate/ds/esa_cci_odp.py
+++ b/cate/ds/esa_cci_odp.py
@@ -1271,8 +1271,8 @@ class EsaCciOdpDataSource(DataSource):
                                      if var_name not in var_names]
                                 )
                             if region:
-                                remote_dataset = normalize_impl(remote_dataset)
                                 remote_dataset = subset_spatial_impl(remote_dataset, region)
+                                remote_dataset = normalize_impl(remote_dataset)
                                 remote_dataset = adjust_spatial_attrs_impl(remote_dataset, allow_point=False)
                                 if do_update_of_region_meta_info_once:
                                     local_ds.meta_info['bbox_minx'] = remote_dataset.attrs['geospatial_lon_min']
@@ -1298,6 +1298,7 @@ class EsaCciOdpDataSource(DataSource):
                                     # Probably related to https://github.com/pydata/xarray/issues/2560.
                                     # And probably fixes Cate issues #823, #822, #818, #816, #783.
                                     remote_dataset.to_netcdf(local_filepath, format=format, engine=engine)
+                                    to_netcdf_attempts=2 # RR upon success, make sure to break out of the while loop (don't save the same stuff twice)
                                 except AttributeError as e:
                                     if to_netcdf_attempts == 1:
                                         format = 'NETCDF3_64BIT'


### PR DESCRIPTION
Dear Cate-devs,

I'm using the cate  on an old machine with little (4gb) ram. When downloading a subset of the land cover data, I ran in to out-of-memory errors because cate tried to somehow load the entire global land_cover array into memory. This seemed odd as I only need a small subset of the data. After some debugging I believe this is triggered by calling xarray' s.expand_dims on the time dimension before any region constraints are applied. After switching the order (applying region constraints before time constraints) it seems to work now. I'm not entirely sure whether this will have consequences, but the locally saved data seemed fine, so I guess it saves bandwidth and time.

Furthermore, I've added a criteria to break out of the loop which saved a dataset to a  netcdf file twice.

Roelof
