### PR TITLE
Let's see if we can drop matplotlib < 3.3 constraint...

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - bokeh>=1.3
   - boto3>=1.14
   - botocore>=1.17
-  - cartopy>=0.17.0
+  - cartopy>=0.18
   - cftime>=1.4.1
   - conda>=4.8
   - cython>=0.29.2
@@ -23,8 +23,7 @@ dependencies:
   - hdf5>=1.10.4
   - jdcal>=1.4.1
   - lxml>=4.5
-  # Workaround to avoid cartopy 0.17.0 / matplotlib 3.3.0 conflict (Issue #927)
-  - matplotlib-base>=3.1.3,<3.3.0
+  - matplotlib-base>=3.3
   - numba>=0.48.0
   - numpy>=1.18.1
   - netcdf4>=1.5.1.2
@@ -46,8 +45,8 @@ dependencies:
   - setuptools
   - shapely>=1.6.4
   - tornado>=6.0
-  - xarray>=0.14
-  - xcube>=0.8
+  - xarray>=0.17
+  - xcube>=0.8.1
   - yaml>=0.2.2
   - zarr>=2.4
   # Test libs


### PR DESCRIPTION
May close https://github.com/CCI-Tools/cate/issues/929