### PR TITLE
matplotlib version issue

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,8 +13,8 @@
   - Parameter `crs` of function `cate.ops.io.read_geo_data_frame` 
 * Fixed bug with user preferences not being saved correctly.
   ([#146](https://github.com/CCI-Tools/cate-app/issues/146))
-* Fixed environment not building with matplotlib version `<3.3.0` ([#929](https://github.com/CCI-Tools/cate/issues/929))
-* Fixed the operators `animate` as well as `plot` not working with the current xarray version (0.18)
+* Fixed environment not building with matplotlib version `<3.3.0`. (#929)
+* Fixed the operation `animate_map` that stopped working with xarray version 0.18.0.
 
 ## Version 2.1.5
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,7 @@
 * Fixed bug with user preferences not being saved correctly.
   ([#146](https://github.com/CCI-Tools/cate-app/issues/146))
 * Fixed environment not building with matplotlib version `<3.3.0` ([#929](https://github.com/CCI-Tools/cate/issues/929))
-* Fixed the operator `animate`not working with the current xarray version (0.18)
+* Fixed the operators `animate` as well as `plot` not working with the current xarray version (0.18)
 
 ## Version 2.1.5
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,8 @@
   - Parameter `crs` of function `cate.ops.io.read_geo_data_frame` 
 * Fixed bug with user preferences not being saved correctly.
   ([#146](https://github.com/CCI-Tools/cate-app/issues/146))
+* Fixed environment not building with matplotlib version `<3.3.0` ([#929](https://github.com/CCI-Tools/cate/issues/929))
+* Fixed the operator `animate`not working with the current xarray version (0.18)
 
 ## Version 2.1.5
 

--- a/cate/ops/animate.py
+++ b/cate/ops/animate.py
@@ -227,11 +227,9 @@ def animate_map(ds: xr.Dataset,
         # transform keyword is for the coordinate our data is in, which in case of a
         # 'normal' lat/lon dataset is PlateCarree.
         if contour_plot:
-            var_data.plot.contourf(ax=ax, transform=ccrs.PlateCarree(), subplot_kws={'projection': proj},
-                                   add_colorbar=True, **plot_kwargs)
+            var_data.plot.contourf(ax=ax, transform=ccrs.PlateCarree(), add_colorbar=True, **plot_kwargs)
         else:
-            var_data.plot.pcolormesh(ax=ax, transform=ccrs.PlateCarree(), subplot_kws={'projection': proj},
-                                     add_colorbar=True, **plot_kwargs)
+            var_data.plot.pcolormesh(ax=ax, transform=ccrs.PlateCarree(), add_colorbar=True, **plot_kwargs)
         if title:
             ax.set_title(title)
         figure.tight_layout()
@@ -246,12 +244,15 @@ def animate_map(ds: xr.Dataset,
             ax.coastlines()
             indexers[animate_dim] = value
             var_data = get_var_data(var, indexers, remaining_dims=('lon', 'lat'))
-            var_data.plot.contourf(ax=ax, transform=ccrs.PlateCarree(), subplot_kws={'projection': proj},
+            var_data.plot.contourf(ax=ax, transform=ccrs.PlateCarree(),
                                    add_colorbar=False, **plot_kwargs)
             if title:
                 ax.set_title(title)
             monitor.progress(1)
             return ax
+
+        # Reports Optional[int] expected but iterable allowed
+        # noinspection PyTypeChecker
         anim = animation.FuncAnimation(figure, run, [i for i in var[animate_dim]],
                                        interval=interval, blit=False, repeat=False)
         anim_html = anim.to_jshtml()

--- a/cate/ops/plot.py
+++ b/cate/ops/plot.py
@@ -71,7 +71,6 @@ import matplotlib.pyplot as plt
 from matplotlib.figure import Figure
 
 import xarray as xr
-import pandas as pd
 import cartopy.crs as ccrs
 import numpy as np
 import json
@@ -208,9 +207,9 @@ def plot_map(ds: xr.Dataset,
     # transform keyword is for the coordinate our data is in, which in case of a
     # 'normal' lat/lon dataset is PlateCarree.
     if contour_plot:
-        var_data.plot.contourf(ax=ax, transform=ccrs.PlateCarree(), subplot_kws={'projection': proj}, **properties)
+        var_data.plot.contourf(ax=ax, transform=ccrs.PlateCarree(), **properties)
     else:
-        var_data.plot.pcolormesh(ax=ax, transform=ccrs.PlateCarree(), subplot_kws={'projection': proj}, **properties)
+        var_data.plot.pcolormesh(ax=ax, transform=ccrs.PlateCarree(), **properties)
 
     if title:
         ax.set_title(title)

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - bokeh>=1.3
   - boto3>=1.14
   - botocore>=1.17
-  - cartopy>=0.17.0
+  - cartopy>=0.18
   - cftime>=1.4.1
   - conda>=4.8
   - cython>=0.29.2
@@ -23,8 +23,7 @@ dependencies:
   - hdf5>=1.10.4
   - jdcal>=1.4.1
   - lxml>=4.5
-  # Workaround to avoid cartopy 0.17.0 / matplotlib 3.3.0 conflict (Issue #927)
-  - matplotlib-base>=3.1.3,<3.3.0
+  - matplotlib-base>=3.3
   - numba>=0.48.0
   - numpy>=1.18.1
   - netcdf4>=1.5.1.2
@@ -46,8 +45,8 @@ dependencies:
   - setuptools
   - shapely>=1.6.4
   - tornado>=6.0
-  - xarray>=0.14
-  - xcube>=0.8
+  - xarray>=0.17
+  - xcube>=0.8.1
   - yaml>=0.2.2
   - zarr>=2.4
   # Test libs


### PR DESCRIPTION
When accepting this PR:

- the matplotlib maximal dependency restriction '<3.3.0' will have been removed
- The conda env will build
- the op animate will work again