### PR TITLE
Return Cate's core package dependencies

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,8 +21,13 @@
     now `dtype` and `dims` fields. 
 * Fixed environment not building with matplotlib version `<3.3.0`. (#929)
 * Fixed the operation `animate_map` that stopped working with xarray version 0.18.0.
-* Added a github action for running unittests
-* Changed Dockerfile to install xcube-cci from GitHub releases
+* Other:
+  * The info handler of Cate Web API (at API root "/") now returns 
+    Cate's core package dependencies.
+  * Added a GitHub Actions workflow for running unittests.
+  * Changed `Dockerfile` to install `xcube` and `xcube-cci` 
+    from GitHub releases.
+
 
 ## Version 2.1.5
 

--- a/cate/webapi/start.py
+++ b/cate/webapi/start.py
@@ -45,25 +45,26 @@ Components
 # warnings.filterwarnings("ignore")  # never print any warnings to users
 
 import os
-import sys
 import platform
+import sys
 from datetime import date
 
-from tornado.web import Application, StaticFileHandler
 from matplotlib.backends.backend_webagg_core import FigureManagerWebAgg
+from tornado.web import Application, StaticFileHandler
 
 from cate.conf.defaults import WEBAPI_LOG_FILE_PREFIX, WEBAPI_PROGRESS_DEFER_PERIOD
 from cate.core.types import ValidationError
 from cate.core.wsmanag import FSWorkspaceManager
+from cate.util.misc import get_dependencies
 from cate.util.web import JsonRpcWebSocketHandler
 from cate.util.web.webapi import run_start, url_pattern, WebAPIRequestHandler, WebAPIExitHandler
 from cate.version import __version__
+from cate.webapi.mpl import MplJavaScriptHandler, MplDownloadHandler, MplWebSocketHandler
 from cate.webapi.rest import ResourcePlotHandler, CountriesGeoJSONHandler, ResVarTileHandler, \
     ResFeatureCollectionHandler, ResFeatureHandler, ResVarCsvHandler, ResVarHtmlHandler, NE2Handler, \
     FilesUploadHandler, FilesDownloadHandler
-from cate.webapi.mpl import MplJavaScriptHandler, MplDownloadHandler, MplWebSocketHandler
-from cate.webapi.websocket import WebSocketService
 from cate.webapi.service import SERVICE_NAME, SERVICE_TITLE
+from cate.webapi.websocket import WebSocketService
 
 # Explicitly load Cate-internal plugins.
 __import__('cate.ds')
@@ -80,11 +81,14 @@ class WebAPIInfoHandler(WebAPIRequestHandler):
         user_root_mode = isinstance(self.application.workspace_manager, FSWorkspaceManager) \
                          and self.application.workspace_manager.root_path is not None
 
-        self.write_status_ok(content={'name': SERVICE_NAME,
-                                      'version': __version__,
-                                      'timestamp': date.today().isoformat(),
-                                      'user_root_mode': user_root_mode,
-                                      'host_os': platform.system()})
+        self.write_status_ok(content={
+            'name': SERVICE_NAME,
+            'version': __version__,
+            'timestamp': date.today().isoformat(),
+            'user_root_mode': user_root_mode,
+            'host_os': platform.system(),
+            'dependencies': get_dependencies()
+        })
 
         self.finish()
 

--- a/tests/util/test_misc.py
+++ b/tests/util/test_misc.py
@@ -1,3 +1,4 @@
+import unittest
 from collections import OrderedDict
 from datetime import datetime, date
 from unittest import TestCase
@@ -5,12 +6,16 @@ from xml.etree.ElementTree import ElementTree
 
 import numpy as np
 
-from cate.util.misc import encode_url_path, to_json, to_scalar
-from cate.util.misc import object_to_qualified_name, qualified_name_to_object
-from cate.util.misc import to_datetime, to_datetime_range
-from cate.util.misc import to_list
-from cate.util.misc import to_str_constant, is_str_constant
+from cate.util.misc import encode_url_path
+from cate.util.misc import get_dependencies
 from cate.util.misc import new_indexed_name
+from cate.util.misc import object_to_qualified_name
+from cate.util.misc import qualified_name_to_object
+from cate.util.misc import to_datetime, to_datetime_range
+from cate.util.misc import to_json
+from cate.util.misc import to_list
+from cate.util.misc import to_scalar
+from cate.util.misc import to_str_constant, is_str_constant
 from cate.util.undefined import UNDEFINED
 
 
@@ -325,3 +330,14 @@ class ToScalarTest(TestCase):
             self.assertIs(to_scalar(pd.Series([True, False])), UNDEFINED)
         except ImportError:
             pass
+
+
+class DependenciesTest(unittest.TestCase):
+    def test_get_dependencies(self):
+        dependencies = get_dependencies()
+        self.assertIsInstance(dependencies, dict)
+        for module in ('xcube', 'xcube_cci', 'xarray', 'geopandas', 'dask'):
+            msg = f'for module {module!r}'
+            self.assertIn(module, dependencies, msg=msg)
+            self.assertIsInstance(dependencies[module], str, msg=msg)
+            self.assertNotEqual('installed', dependencies[module], msg=msg)


### PR DESCRIPTION
The info handler of Cate Web API (at API root "/") now returns Cate's core package dependencies:

![image](https://user-images.githubusercontent.com/206773/122208604-cf6dc200-cea3-11eb-84ef-fbe6004e603f.png)
