### PR TITLE
Dzelge xxx docker img deps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,7 @@ jobs:
           conda list
           python setup.py develop
       - name: setup-xcube
+        shell: bash -l {0}
         run: |
           wget https://github.com/dcs4cop/xcube/archive/v"${XCUBE_VERSION}".tar.gz
           tar xvzf v"${XCUBE_VERSION}".tar.gz
@@ -33,6 +34,7 @@ jobs:
           mamba env update -n cate-env
           python setup.py install
       - name: setup-xcube-cci
+        shell: bash -l {0}
         run: |
           wget https://github.com/dcs4cop/xcube/archive/v"${XCUBE_CCI_VERSION}".tar.gz
           tar xvzf v"${XCUBE_CCI_VERSION}".tar.gz

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,14 +32,14 @@ jobs:
 
           mamba env update -n cate-env
 
-          source activate cate-env
+          conda activate cate-env
           python setup.py install
       - name: setup-xcube-cci
         run: |
           wget https://github.com/dcs4cop/xcube/archive/v"${XCUBE_CCI_VERSION}".tar.gz
           tar xvzf v"${XCUBE_CCI_VERSION}".tar.gz
           cd xcube-"${XCUBE_CCI_VERSION}"
-          source activate cate-env
+          conda activate cate-env
           python setup.py install
           mamba install -y -c conda-forge aiohttp nest-asyncio lxml pydap
       - name: unittest-cate

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,15 +31,12 @@ jobs:
           cd xcube-"${XCUBE_VERSION}"
 
           mamba env update -n cate-env
-
-          conda activate cate-env
           python setup.py install
       - name: setup-xcube-cci
         run: |
           wget https://github.com/dcs4cop/xcube/archive/v"${XCUBE_CCI_VERSION}".tar.gz
           tar xvzf v"${XCUBE_CCI_VERSION}".tar.gz
           cd xcube-"${XCUBE_CCI_VERSION}"
-          conda activate cate-env
           python setup.py install
           mamba install -y -c conda-forge aiohttp nest-asyncio lxml pydap
       - name: unittest-cate

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,5 +50,6 @@ jobs:
           export CATE_DISABLE_WEB_TESTS=1
           # geopandas in tests break the build on appveyor (maybe the problem of gdal?)
           export CATE_DISABLE_GEOPANDAS_TESTS=1
-          export CATE_DISABLE_PLOT_TESTS=1
+          export CATE_DISABLE_PLOT_TESTS=
+          export CATE_DISABLE_CLI_UPDATE_TESTS=1
           py.test -v --cov=cate tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,9 @@ on: push
 
 jobs:
   unittest:
+    env:
+      XCUBE_VERSION: 0.8.2.dev0
+      XCUBE_CCI_VERSION: 0.8.1.dev1
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: strip-xcube
+        run: sed -i 's/- xcube/# -xcube/g' environment.yml
       - uses: conda-incubator/setup-miniconda@v2
         with:
           mamba-version: "*"
@@ -19,6 +21,24 @@ jobs:
           conda info
           conda list
           python setup.py develop
+      - name: setup-xcube
+        run: |
+          wget https://github.com/dcs4cop/xcube/archive/v"${XCUBE_VERSION}".tar.gz
+          tar xvzf v"${XCUBE_VERSION}".tar.gz
+          cd xcube-"${XCUBE_VERSION}"
+
+          mamba env update -n cate-env
+
+          source activate cate-env
+          python setup.py install
+      - name: setup-xcube-cci
+        run: |
+          wget https://github.com/dcs4cop/xcube/archive/v"${XCUBE_CCI_VERSION}".tar.gz
+          tar xvzf v"${XCUBE_CCI_VERSION}".tar.gz
+          cd xcube-"${XCUBE_CCI_VERSION}"
+          source activate cate-env
+          python setup.py install
+          mamba install -y -c conda-forge aiohttp nest-asyncio lxml pydap
       - name: unittest-cate
         shell: bash -l {0}
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,9 +36,9 @@ jobs:
       - name: setup-xcube-cci
         shell: bash -l {0}
         run: |
-          wget https://github.com/dcs4cop/xcube/archive/v"${XCUBE_CCI_VERSION}".tar.gz
+          wget https://github.com/dcs4cop/xcube-cci/archive/v"${XCUBE_CCI_VERSION}".tar.gz
           tar xvzf v"${XCUBE_CCI_VERSION}".tar.gz
-          cd xcube-"${XCUBE_CCI_VERSION}"
+          cd xcube-cci-"${XCUBE_CCI_VERSION}"
           python setup.py install
           mamba install -y -c conda-forge aiohttp nest-asyncio lxml pydap
       - name: unittest-cate

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,7 +27,8 @@
   * Added a GitHub Actions workflow for running unittests.
   * Changed `Dockerfile` to install `xcube` and `xcube-cci` 
     from GitHub releases.
-
+* Updated Dockerfile. The docker image now uses a cate environment that is stripped free of any xcube deps allowing 
+  to configure the versions of xcube/xcube-cci. These versions are now installed from their respective GitHub release.
 
 ## Version 2.1.5
 


### PR DESCRIPTION
When accepting this PR cate's docker image will use a cate environment that is stripped free of any xcube deps allowing 
  to configure the versions of xcube/xcube-cci. These versions are now installed from their respective GitHub release.