### PR TITLE
docker: when runnning a cate container it complains that cate is not …

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,12 +18,6 @@ jobs:
           channels: conda-forge
           activate-environment: cate-env
           environment-file: environment.yml
-      - name: setup-cate
-        shell: bash -l {0}
-        run: |
-          conda info
-          conda list
-          python setup.py develop
       - name: setup-xcube
         shell: bash -l {0}
         run: |
@@ -41,6 +35,12 @@ jobs:
           cd xcube-cci-"${XCUBE_CCI_VERSION}"
           python setup.py install
           mamba install -y -c conda-forge aiohttp nest-asyncio lxml pydap
+      - name: setup-cate
+        shell: bash -l {0}
+        run: |
+          conda info
+          conda list
+          python setup.py develop
       - name: unittest-cate
         shell: bash -l {0}
         run: |

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,7 +26,8 @@
     Cate's core package dependencies.
   * Added a GitHub Actions workflow for running unittests.
   * Changed `Dockerfile` to install `xcube` and `xcube-cci` 
-    from GitHub releases. 
+    from GitHub releases
+* Fixed bug in docker image: Teh cate package is now installed properly    
 
 ## Version 2.1.5
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 <img alt="Cate: ESA CCI Toolbox" align="right" src="https://raw.githubusercontent.com/CCI-Tools/cate/master/doc/source/_static/logo/cci-toolbox-logo-latex.jpg" />
 
 [![Build status](https://ci.appveyor.com/api/projects/status/leugvo8fq7nx6kym/branch/master?svg=true)](https://ci.appveyor.com/project/ccitools/cate-core)
+https://github.com/CCI-Tools/cate/actions/workflows/test.yml/badge.svg
 [![codecov.io](https://codecov.io/github/CCI-Tools/cate/coverage.svg?branch=master)](https://codecov.io/github/CCI-Tools/cate?branch=master)
 [![Documentation Status](https://readthedocs.org/projects/cate/badge/?version=latest)](http://cate.readthedocs.io/en/latest/?badge=latest)
                 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <img alt="Cate: ESA CCI Toolbox" align="right" src="https://raw.githubusercontent.com/CCI-Tools/cate/master/doc/source/_static/logo/cci-toolbox-logo-latex.jpg" />
 
 [![Build status](https://ci.appveyor.com/api/projects/status/leugvo8fq7nx6kym/branch/master?svg=true)](https://ci.appveyor.com/project/ccitools/cate-core)
-https://github.com/CCI-Tools/cate/actions/workflows/test.yml/badge.svg
+[![GH actions Build status](https://github.com/CCI-Tools/cate/actions/workflows/test.yml/badge.svg)](https://github.com/CCI-Tools/cate/actions/workflows/test.yml/badge.svg)
 [![codecov.io](https://codecov.io/github/CCI-Tools/cate/coverage.svg?branch=master)](https://codecov.io/github/CCI-Tools/cate?branch=master)
 [![Documentation Status](https://readthedocs.org/projects/cate/badge/?version=latest)](http://cate.readthedocs.io/en/latest/?badge=latest)
                 

--- a/cate/version.py
+++ b/cate/version.py
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 # Cate version string (PEP440-compatible), e.g. "0.8.0", "0.8.0.dev1", "0.8.0rc1", "0.8.0rc1.dev1"
-__version__ = '3.0.0.dev3'
+__version__ = '3.0.0.dev4'
 
 # Other package metainfo
 __title__ = 'cate'


### PR DESCRIPTION
When accepting this PR the cate docker container will not complain anymore about a missing cate package.  When creating the docker image, cate was installed in the python 3.7 lib directory, However, xcube (all of a sudden) change Python to version 3.9 which hid the cate installation.