### PR TITLE
Toniof xxx open local zarrs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ## Version 3.0.1 (in development) 
-* Fixed bug that would cause that no local zarr datasets could be opened. 
+* Fixed bug that would cause that data that was downloaded and cached locally
+  could not be opened. 
 
 ## Version 3.0.0 
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+## Version 3.0.1 (in development) 
+* Fixed bug that would cause that no local zarr datasets could be opened. 
+
 ## Version 3.0.0 
 
 * Cate's implementations of the CCI ODP data store and the local data store 

--- a/cate/core/ds.py
+++ b/cate/core/ds.py
@@ -448,7 +448,10 @@ def open_dataset(dataset_id: str,
             subset_args['bbox'] = bbox
             subset_work += 1
 
-    if 'consolidated' in open_schema.properties:
+    #TODO remove when xcube 0.9 is available
+    if 'consolidated' in open_schema.properties and not \
+            isinstance(data_store,
+                       xcube_store.stores.directory.DirectoryDataStore):
         open_args['consolidated'] = True
 
     with monitor.starting('Open dataset', open_work + subset_work + cache_work):

--- a/cate/version.py
+++ b/cate/version.py
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 # Cate version string (PEP440-compatible), e.g. "0.8.0", "0.8.0.dev1", "0.8.0rc1", "0.8.0rc1.dev1"
-__version__ = '3.0.0'
+__version__ = '3.0.1.dev0'
 
 # Other package metainfo
 __title__ = 'cate'


### PR DESCRIPTION
Fixes that zarr datasets could not be opened when they were provided by an xcube directory data store. 