### PR TITLE
Fixed cate-webapi-start with --auto-stop-after <seconds>

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,8 @@
 ## Version 3.0.1 (in development) 
+
+* The `--auto-stop-after <seconds>` option now works correctly with 
+  Cate service CLI `cate-webapi-start` command. It will be used to 
+  automatically stop inactivate Cate Cloud Service instances.
 * Fixed bug that would cause that data that was downloaded and cached locally
   could not be opened. 
 * Increased xcube >=0.9.1 and xcube-cci version to >=0.9.0 and fixed issues 

--- a/cate/util/web/webapi.py
+++ b/cate/util/web/webapi.py
@@ -265,7 +265,7 @@ class WebAPI:
         # noinspection PyArgumentList
         application = application_factory(user_root_path=user_root_path)
         application.webapi = self
-        application.time_of_last_activity = time.process_time()
+        application.time_of_last_activity = time.perf_counter()
         self.application = application
 
         print(f'{name}: started service, listening on {join_address_and_port(address, port)}')
@@ -411,7 +411,7 @@ class WebAPI:
     def _check_inactivity(self):
         # noinspection PyUnresolvedReferences
         time_of_last_activity = self.application.time_of_last_activity
-        inactivity_time = time.process_time() - time_of_last_activity
+        inactivity_time = time.perf_counter() - time_of_last_activity
         if inactivity_time > self.auto_stop_after:
             _LOG.info('stopping %s service after %.1f seconds of inactivity' % (self.name, inactivity_time))
             self.shut_down()
@@ -617,7 +617,7 @@ class WebAPIRequestHandler(RequestHandler):
         """
         Store time of last activity so we can measure time of inactivity and then optionally auto-exit.
         """
-        self.application.time_of_last_activity = time.process_time()
+        self.application.time_of_last_activity = time.perf_counter()
 
     def write_status_ok(self, content: object = None):
         self.write(dict(status='ok', content=content))


### PR DESCRIPTION
The `--auto-stop-after <seconds>` option now works correctly with Cate service CLI `cate-webapi-start` command. It will be used to automatically stop inactivate Cate Cloud Service instances.