### PR TITLE
Improve logging

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,7 @@
 
 ## Version 3.1.1
 
-* Use xcube-cci version 0.9.3 in docker files  
+* Now using package `xcube-cci 0.9.3` in Docker files.
 
 ## Version 3.1.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,16 @@
 ## Version 3.1.2 (in development)
 
+* Improved logging for `cate-webapi-start` to allow for 
+  improved error analysis:
+  - Added new option `--logfile`.
+  - Changed meaning of option `--verbose`. Using this flag now 
+    sets log level to `DEBUG`. Warning: this setting affects all
+    loggers, so expect vast output.
+  - Cate now outputs extra debugging information, if 
+    environment variable `CATE_DEBUG` is set to `1`. 
+    This affects WebSocket communication, image tile computations,
+    and image tile caching. Output will always be streamed 
+    to stdout.
 
 ## Version 3.1.1
 

--- a/cate/cli/main.py
+++ b/cate/cli/main.py
@@ -109,8 +109,8 @@ import warnings
 from collections import OrderedDict
 from typing import Tuple, Union, List, Dict, Any, Optional
 
-from cate.version import __version__
 from cate.util.cli import run_main, Command, SubCommandCommand, CommandError
+from cate.version import __version__
 
 __author__ = "Norman Fomferra (Brockmann Consult GmbH), " \
              "Marco Zühlke (Brockmann Consult GmbH)"
@@ -147,7 +147,9 @@ NullableStr = Union[str, None]
 
 
 def _default_workspace_manager_factory() -> Any:
-    from cate.conf.defaults import WEBAPI_INFO_FILE, WEBAPI_ON_INACTIVITY_AUTO_STOP_AFTER
+    from cate.conf.defaults import WEBAPI_LOG_FILE
+    from cate.conf.defaults import WEBAPI_INFO_FILE
+    from cate.conf.defaults import WEBAPI_ON_INACTIVITY_AUTO_STOP_AFTER
     from cate.webapi.wsmanag import WebAPIWorkspaceManager
     from cate.util.web.webapi import read_service_info, is_service_running, WebAPI
 
@@ -158,6 +160,7 @@ def _default_workspace_manager_factory() -> Any:
                                                   service_info.get('address'), timeout=5.):
         WebAPI.start_subprocess(CATE_WEBAPI_START_MODULE,
                                 caller=CLI_NAME,
+                                log_file=WEBAPI_LOG_FILE,
                                 service_info_file=WEBAPI_INFO_FILE,
                                 auto_stop_after=WEBAPI_ON_INACTIVITY_AUTO_STOP_AFTER)
         # Read new '.cate/webapi.json'

--- a/cate/conf/defaults.py
+++ b/cate/conf/defaults.py
@@ -69,8 +69,8 @@ WEBAPI_WORKSPACE_MEM_TILE_CACHE_CAPACITY = 256 * _ONE_MIB
 #: where the information about a running WebAPI service is stored
 WEBAPI_INFO_FILE = os.path.join(DEFAULT_VERSION_DATA_PATH, 'webapi.json')
 
-#: where a running WebAPI service logs to
-WEBAPI_LOG_FILE_PREFIX = os.path.join(DEFAULT_VERSION_DATA_PATH, 'webapi.log')
+#: where a running WebAPI service logs to (used for CLI only)
+WEBAPI_LOG_FILE = os.path.join(DEFAULT_VERSION_DATA_PATH, 'webapi.log')
 
 #: allow a 100 ms period between two progress messages sent to the client
 WEBAPI_PROGRESS_DEFER_PERIOD = 0.5

--- a/cate/util/cache.py
+++ b/cate/util/cache.py
@@ -1,5 +1,5 @@
 # The MIT License (MIT)
-# Copyright (c) 2016, 2017 by the ESA CCI Toolbox development team and contributors
+# Copyright (c) 2021 by the ESA CCI Toolbox development team and contributors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in
@@ -55,10 +55,11 @@ import time
 from abc import ABCMeta, abstractmethod
 from threading import RLock
 
+from .misc import is_debug_mode
+
 __author__ = "Norman Fomferra (Brockmann Consult GmbH)"
 
-# _DEBUG_CACHE = True
-_DEBUG_CACHE = False
+_DEBUG_CACHE = is_debug_mode()
 
 
 class CacheStore(metaclass=ABCMeta):

--- a/cate/util/misc.py
+++ b/cate/util/misc.py
@@ -549,3 +549,17 @@ def get_dependencies() -> Dict[str, str]:
                 dependencies_dict[module_key] = "installed"
 
     return dependencies_dict
+
+
+_DEBUG_MODE = None
+
+
+def is_debug_mode() -> bool:
+    global _DEBUG_MODE
+    if _DEBUG_MODE is None:
+        # noinspection PyBroadException
+        try:
+            _DEBUG_MODE = bool(int(os.getenv('CATE_DEBUG', '0')))
+        except Exception:
+            _DEBUG_MODE = False
+    return _DEBUG_MODE

--- a/cate/util/web/common.py
+++ b/cate/util/web/common.py
@@ -19,11 +19,12 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import os
 import traceback
 from typing import Optional
 
-_DEBUG_MODE = bool(int(os.getenv('CATE_DEBUG', '0')))
+from ..misc import is_debug_mode
+
+_DEBUG_MODE = is_debug_mode()
 
 
 def is_debug_mode() -> bool:

--- a/cate/util/web/common.py
+++ b/cate/util/web/common.py
@@ -1,5 +1,5 @@
 # The MIT License (MIT)
-# Copyright (c) 2016, 2017 by the ESA CCI Toolbox development team and contributors
+# Copyright (c) 2021 by the ESA CCI Toolbox development team and contributors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in
@@ -19,10 +19,11 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import os
 import traceback
 from typing import Optional
 
-_DEBUG_MODE = False
+_DEBUG_MODE = bool(os.getenv('CATE_DEBUG', False))
 
 
 def is_debug_mode() -> bool:

--- a/cate/util/web/common.py
+++ b/cate/util/web/common.py
@@ -23,7 +23,7 @@ import os
 import traceback
 from typing import Optional
 
-_DEBUG_MODE = bool(os.getenv('CATE_DEBUG', False))
+_DEBUG_MODE = bool(int(os.getenv('CATE_DEBUG', '0')))
 
 
 def is_debug_mode() -> bool:

--- a/cate/util/web/jsonrpchandler.py
+++ b/cate/util/web/jsonrpchandler.py
@@ -121,7 +121,7 @@ class JsonRpcWebSocketHandler(WebSocketHandler):
         return True
 
     def on_message(self, message: str):
-        _LOG.debug('JSON RPC message: %s' % message)
+        _LOG.debug('JSON RPC message: %s', message)
 
         # Note, the following error cases 1-4 cannot be communicated to client as we
         # haven't got a valid method "id" which is required for a JSON-RPC response

--- a/cate/util/web/webapi.py
+++ b/cate/util/web/webapi.py
@@ -23,7 +23,6 @@ import argparse
 import asyncio
 import logging
 import os.path
-import requests
 import signal
 import subprocess
 import sys
@@ -33,10 +32,9 @@ import traceback
 from datetime import datetime
 from typing import List, Callable, Optional, Tuple
 
+import requests
 # from tornado.platform.asyncio import AnyThreadEventLoopPolicy
-import tornado.options
 from tornado.ioloop import IOLoop
-from tornado.log import enable_pretty_logging
 from tornado.web import RequestHandler, Application
 
 from cate.core.common import default_user_agent
@@ -75,7 +73,6 @@ def run_start(name: str,
               description: str,
               version: str,
               application_factory: ApplicationFactory,
-              log_file_prefix: str = None,
               args: List[str] = None) -> int:
     """
     Run the WebAPI command-line interface.
@@ -84,7 +81,6 @@ def run_start(name: str,
     :param description: The CLI's description.
     :param version: The CLI's version string.
     :param application_factory: A no-arg function that creates a Tornado web application instance.
-    :param log_file_prefix: Log file prefix name.
     :param args: The command-line arguments, may be None.
     :return: the exit code, zero on success.
     """
@@ -94,25 +90,33 @@ def run_start(name: str,
     parser = _get_common_cli_parser(name, description, version)
     parser.add_argument('--file', '-f', dest='file', metavar='FILE',
                         help="write service information to FILE")
-    parser.add_argument('--auto-stop-after', '-s', dest='auto_stop_after', metavar='AUTO_STOP_AFTER', type=float,
-                        help="stop service after AUTO_STOP_AFTER seconds of inactivity")
+    parser.add_argument('--auto-stop-after', '-s', dest='auto_stop_after',
+                        metavar='AUTO_STOP_AFTER', type=float,
+                        help="stop service after AUTO_STOP_AFTER"
+                             " seconds of inactivity")
+    parser.add_argument('--logfile', '-l', dest='log_file',
+                        help="log file path. If omitted, log output is"
+                             " redirected to stderr.")
     parser.add_argument('--verbose', '-v', dest='verbose', action='store_true',
-                        help="delegate log output to the console (stderr)")
+                        help="verbose logging."
+                             " Will also log debugging messages.")
 
     args_obj = parser.parse_args(args)
 
     try:
-        if not os.path.isdir(os.path.dirname(log_file_prefix)):
-            os.makedirs(os.path.dirname(log_file_prefix), exist_ok=True)
+        log_file = args_obj.log_file
+        if log_file is not None \
+                and not os.path.isdir(os.path.dirname(log_file)):
+            os.makedirs(os.path.dirname(log_file), exist_ok=True)
 
         service = WebAPI()
         service.start(name, application_factory,
-                      log_file_prefix=log_file_prefix,
-                      log_to_stderr=args_obj.verbose,
+                      verbose=args_obj.verbose,
                       port=args_obj.port,
                       address=args_obj.address,
                       caller=args_obj.caller,
                       user_root_path=args_obj.user_root_path,
+                      log_file=log_file,
                       service_info_file=args_obj.file,
                       auto_stop_after=args_obj.auto_stop_after)
 
@@ -197,8 +201,8 @@ class WebAPI:
     def start(self,
               name: str,
               application_factory: ApplicationFactory,
-              log_file_prefix: str = None,
-              log_to_stderr: bool = False,
+              log_file: str = None,
+              verbose: bool = False,
               auto_stop_after: float = None,
               port: int = None,
               address: str = None,
@@ -218,8 +222,8 @@ class WebAPI:
         :param user_root_path: Root path for the user
         :param name: The (CLI) name of this service.
         :param application_factory: no-arg function which is used to create
-        :param log_file_prefix: Log file prefix, default is "webapi.log"
-        :param log_to_stderr: Whether logging should be shown on stderr
+        :param log_file: Log file prefix, default is "webapi.log"
+        :param verbose: Verbose logging. Will also log debugging messages.
         :param auto_stop_after: if not-None, time of idleness in seconds before service is terminated
         :param port: the port number
         :param address: the address
@@ -243,11 +247,17 @@ class WebAPI:
                 print(f'{name}: service info file exists:{service_info_file}, removing it')
                 os.remove(service_info_file)
 
-        options = tornado.options.options
-        # Check, we should better use a log file per caller, e.g. "~/.cate/webapi-%s.log" % caller
-        options.log_file_prefix = log_file_prefix or f'{name}.log'
-        # options.log_to_stderr = log_to_stderr
-        enable_pretty_logging(logger=logging.getLogger("tornado"))
+        logging_config = dict(
+            format='%(asctime)s - %(levelname)s - %(message)s',
+            datefmt='%Y-%m-%d %H:%M:%S',
+            level=logging.DEBUG if verbose else logging.INFO,
+            force=True
+        )
+        if log_file:
+            logging_config.update(
+                filename=f'{log_file}/cate-webapi.log'
+            )
+        logging.basicConfig(**logging_config)
 
         port = port or find_free_port()
 
@@ -268,7 +278,8 @@ class WebAPI:
         application.time_of_last_activity = time.perf_counter()
         self.application = application
 
-        print(f'{name}: started service, listening on {join_address_and_port(address, port)}')
+        _LOG.info(f'{name}: started service,'
+                  f' listening on {join_address_and_port(address, port)}')
 
         self.server = application.listen(port, address='' if address == 'localhost' else address,
                                          max_body_size=1024 * 1024 * 1024,
@@ -302,7 +313,8 @@ class WebAPI:
         :param address: service address
         :param caller:
         :param service_info_file:
-        :param kill_after: if not ``None``, the number of seconds to wait after a hanging service process will be killed
+        :param kill_after: if not ``None``, the number of seconds
+            to wait after a hanging service process will be killed
         :param timeout:
         :return: service information dictionary
         """
@@ -319,19 +331,23 @@ class WebAPI:
         pid = service_info.get('pid')
 
         if not port:
-            raise WebAPIServiceError('cannot stop %s service on unknown port (caller: %s)' % (name, caller))
+            raise WebAPIServiceError('cannot stop %s service'
+                                     ' on unknown port (caller: %s)'
+                                     % (name, caller))
 
         if service_info_file and service_info:
-            print(f'{name}: service information file found: {service_info_file}')
+            print(f'{name}: service information file found:'
+                  f' {service_info_file}')
 
-        print(f'{name}: trying to stop any service on {join_address_and_port(address, port)}')
+        print(f'{name}: trying to stop any service on'
+              f' {join_address_and_port(address, port)}')
 
         # noinspection PyBroadException
         try:
             with requests.request('GET', f'http://{join_address_and_port(address, port)}/exit',
                                   timeout=timeout * 0.3,
                                   headers={'User-Agent': default_user_agent()}) as response:
-                response.text
+                _ = response.text
         except Exception:
             # Either process does not exist, or timeout, or some other error
             pass
@@ -354,29 +370,6 @@ class WebAPI:
                     os.remove(service_info_file)
 
         return dict(port=port, address=address, caller=caller, started=service_info.get('started', None))
-
-    def check_for_auto_stop(self, condition: bool, interval: float = 100):
-        """
-        If *condition* is True, the WebAPI service will end after *interval* seconds.
-
-        :param condition: The condition
-        :param interval: The time in seconds before the service is shut down.
-        :return:
-        """
-        # noinspection PyUnresolvedReferences
-        if not self.auto_stop_enabled:
-            return
-        if self.auto_stop_timer is not None:
-            # noinspection PyBroadException
-            try:
-                self.auto_stop_timer.cancel()
-            except Exception:
-                pass
-        if condition:
-            self.auto_stop_timer = threading.Timer(interval, self.shut_down)
-            self.auto_stop_timer.start()
-        else:
-            self.auto_stop_timer = None
 
     def shut_down(self):
         """
@@ -406,17 +399,25 @@ class WebAPI:
         IOLoop.current().add_callback_from_signal(self._on_shut_down)
 
     def _install_next_inactivity_check(self):
-        IOLoop.current().call_later(self.auto_stop_after, self._check_inactivity)
+        IOLoop.current().call_later(self.auto_stop_after,
+                                    self._check_inactivity)
 
     def _check_inactivity(self):
         # noinspection PyUnresolvedReferences
         time_of_last_activity = self.application.time_of_last_activity
         inactivity_time = time.perf_counter() - time_of_last_activity
         if inactivity_time > self.auto_stop_after:
-            _LOG.info('stopping %s service after %.1f seconds of inactivity' % (self.name, inactivity_time))
-            self.shut_down()
+            self._handle_auto_shut_down(inactivity_time)
         else:
             self._install_next_inactivity_check()
+
+    def _handle_auto_shut_down(self, inactivity_time: float):
+        """
+        Automatically stop the Tornado web server.
+        """
+        _LOG.info('%s: stopping service after %.1f seconds of'
+                  ' inactivity' % (self.name, inactivity_time))
+        self.shut_down()
 
     @classmethod
     def start_subprocess(cls,
@@ -424,6 +425,7 @@ class WebAPI:
                          port: int = None,
                          address: str = None,
                          caller: str = None,
+                         log_file: str = None,
                          service_info_file: str = None,
                          auto_stop_after: float = None,
                          timeout: float = 10.0) -> None:
@@ -434,13 +436,21 @@ class WebAPI:
         :param port: the port number, if not given, a new free port will be searched.
         :param address: the service address, if not given, "localhost" will be used.
         :param caller: the caller's program name
+        :param log_file: optional path to a text file that receives logging output
         :param service_info_file: optional path to a (JSON) file, where service info will be stored
         :param auto_stop_after: if not-None, time of idleness in seconds before service will automatically stop
         :param timeout: timeout in seconds
         """
         port = port or find_free_port()
-        command = cls._join_subprocess_command(module, port, address, caller, service_info_file,
-                                               auto_stop_after)
+        command = cls._join_subprocess_command(
+            module=module,
+            port=port,
+            address=address,
+            caller=caller,
+            log_file=log_file,
+            service_info_file=service_info_file,
+            auto_stop_after=auto_stop_after
+        )
         webapi = subprocess.Popen(command, shell=True)
         webapi_url = f'http://{join_address_and_port(address, port)}/'
         t0 = time.process_time()
@@ -488,7 +498,14 @@ class WebAPI:
             raise ValueError('WebAPI service terminated with exit code %d' % exit_code)
 
     @classmethod
-    def _join_subprocess_command(cls, module, port, address, caller, service_info_file, auto_stop_after):
+    def _join_subprocess_command(cls,
+                                 module,
+                                 port,
+                                 address,
+                                 caller,
+                                 log_file,
+                                 service_info_file,
+                                 auto_stop_after):
         command = '"%s" -m %s' % (sys.executable, module)
         if port:
             command += ' -p %d' % port
@@ -496,18 +513,13 @@ class WebAPI:
             command += ' -a "%s"' % address
         if caller:
             command += ' -c "%s"' % caller
+        if log_file:
+            command += ' -l "%s"' % log_file
         if service_info_file:
             command += ' -f "%s"' % service_info_file
         if auto_stop_after:
             command += ' -s %s' % auto_stop_after
         return command
-
-
-def check_for_auto_stop(application: Application, condition: bool,
-                        interval: float = 100):
-    webapi = WebAPI.get_webapi(application)
-    if webapi:
-        webapi.check_for_auto_stop(condition, interval)
 
 
 # noinspection PyAbstractClass
@@ -676,7 +688,9 @@ class _GlobalEventLoopPolicy(asyncio.DefaultEventLoopPolicy):
         # we are patching run_until_complete here. As the global loop is always running
         # (and across multiple threads), we call run_coroutine_threadsafe instead
         def run_until_complete(future):
-            return asyncio.run_coroutine_threadsafe(future, global_loop).result()
+            return asyncio.run_coroutine_threadsafe(future,
+                                                    global_loop).result()
+
         global_loop.run_until_complete = run_until_complete
 
         self._global_loop = global_loop

--- a/cate/util/web/webapi.py
+++ b/cate/util/web/webapi.py
@@ -415,8 +415,8 @@ class WebAPI:
         """
         Automatically stop the Tornado web server.
         """
-        _LOG.info('%s: stopping service after %.1f seconds of'
-                  ' inactivity' % (self.name, inactivity_time))
+        _LOG.warning('%s: stopping service after %.1f seconds of'
+                     ' inactivity' % (self.name, inactivity_time))
         self.shut_down()
 
     @classmethod

--- a/cate/webapi/rest.py
+++ b/cate/webapi/rest.py
@@ -38,8 +38,8 @@ import geopandas as gpd
 import numpy as np
 import tornado.gen
 import tornado.web
-from tornado import escape
 import xarray as xr
+from tornado import escape
 
 from .geojson import write_feature_collection, write_feature
 from ..conf import get_config
@@ -47,7 +47,6 @@ from ..conf.defaults import \
     WORKSPACE_CACHE_DIR_NAME, \
     WEBAPI_WORKSPACE_FILE_TILE_CACHE_CAPACITY, \
     WEBAPI_WORKSPACE_MEM_TILE_CACHE_CAPACITY, \
-    WEBAPI_ON_ALL_CLOSED_AUTO_STOP_AFTER, \
     WEBAPI_USE_WORKSPACE_IMAGERY_CACHE
 from ..core.cdm import get_tiling_scheme
 from ..core.types import GeoDataFrame
@@ -56,6 +55,7 @@ from ..util.cache import Cache, MemoryCacheStore, FileCacheStore
 from ..util.im import ImagePyramid, TransformArrayImage, ColorMappedRgbaImage
 from ..util.im.ds import NaturalEarth2Image
 from ..util.misc import cwd
+from ..util.misc import is_debug_mode
 from ..util.monitor import Monitor, ConsoleMonitor
 from ..util.web.webapi import WebAPIRequestHandler
 from ..version import __version__
@@ -71,7 +71,7 @@ MEM_TILE_CACHE = Cache(MemoryCacheStore(),
 # Note, the following "get_config()" call in the code will make sure "~/.cate/<version>" is created
 USE_WORKSPACE_IMAGERY_CACHE = get_config().get('use_workspace_imagery_cache', WEBAPI_USE_WORKSPACE_IMAGERY_CACHE)
 
-TRACE_PERF = True
+TRACE_PERF = is_debug_mode()
 
 THREAD_POOL = concurrent.futures.ThreadPoolExecutor()
 
@@ -582,7 +582,7 @@ class FilesUploadHandler(WebAPIRequestHandler):
                                       len(self.meta['boundary'])
 
         self.truncate_fp()
-        megabytes = int(self.meta['content_length'] / 2**20)
+        megabytes = int(self.meta['content_length'] / 2 ** 20)
         self.finish(json.dumps({'status': 'success', 'message': str(megabytes) + 'MBs uploaded.'}))
 
 

--- a/cate/webapi/rest.py
+++ b/cate/webapi/rest.py
@@ -57,7 +57,7 @@ from ..util.im import ImagePyramid, TransformArrayImage, ColorMappedRgbaImage
 from ..util.im.ds import NaturalEarth2Image
 from ..util.misc import cwd
 from ..util.monitor import Monitor, ConsoleMonitor
-from ..util.web.webapi import WebAPIRequestHandler, check_for_auto_stop
+from ..util.web.webapi import WebAPIRequestHandler
 from ..version import __version__
 
 # TODO (forman): We must keep a MemoryCacheStore Cache for each workspace.
@@ -634,13 +634,6 @@ class FilesDownloadHandler(WebAPIRequestHandler):
 
 def _new_monitor() -> Monitor:
     return ConsoleMonitor(stay_in_line=True, progress_bar_size=30)
-
-
-def _on_workspace_closed(application: tornado.web.Application):
-    # noinspection PyUnresolvedReferences
-    workspace_manager = application.workspace_manager
-    num_open_workspaces = workspace_manager.num_open_workspaces()
-    check_for_auto_stop(application, num_open_workspaces == 0, interval=WEBAPI_ON_ALL_CLOSED_AUTO_STOP_AFTER)
 
 
 def _level_to_conservation_ratio(level: int, num_levels: int):

--- a/cate/webapi/start.py
+++ b/cate/webapi/start.py
@@ -44,6 +44,7 @@ Components
 # import warnings
 # warnings.filterwarnings("ignore")  # never print any warnings to users
 
+import logging
 import os
 import platform
 import sys
@@ -52,7 +53,7 @@ from datetime import date
 from matplotlib.backends.backend_webagg_core import FigureManagerWebAgg
 from tornado.web import Application, StaticFileHandler
 
-from cate.conf.defaults import WEBAPI_LOG_FILE_PREFIX, WEBAPI_PROGRESS_DEFER_PERIOD
+from cate.conf.defaults import WEBAPI_PROGRESS_DEFER_PERIOD
 from cate.core.types import ValidationError
 from cate.core.wsmanag import FSWorkspaceManager
 from cate.util.misc import get_dependencies
@@ -72,6 +73,8 @@ __import__('cate.ops')
 
 __author__ = "Norman Fomferra (Brockmann Consult GmbH), " \
              "Marco Zühlke (Brockmann Consult GmbH)"
+
+_LOG = logging.getLogger('cate')
 
 
 # noinspection PyAbstractClass
@@ -110,8 +113,9 @@ def create_application(user_root_path: str = None):
     # replace default url_root with /user/username/ if running in Cate Hub context.
     url_root = os.environ.get("JUPYTERHUB_SERVICE_PREFIX", default_url_root)
     if url_root is not default_url_root:
-        print(f"warning: detected jupyterhub environment variable JUPYTERHUB_SERVICE_PREFIX "
-              f"using {url_root} as default root url for the api.")
+        _LOG.warning(f"detected environment variable"
+                     f" JUPYTERHUB_SERVICE_PREFIX using {url_root}"
+                     f" as default root URL for the API.")
 
     application = Application([
         (url_root + '_static/(.*)', StaticFileHandler, {'path': FigureManagerWebAgg.get_static_file_path()}),
@@ -141,7 +145,8 @@ def create_application(user_root_path: str = None):
     if user_root_path is None:
         user_root_path = default_user_root_path
     elif default_user_root_path:
-        print(f"warning: user root path given by environment variable CATE_USER_ROOT superseded by {user_root_path}")
+        _LOG.warning(f"user root path given by environment variable"
+                     f" CATE_USER_ROOT superseded by {user_root_path}")
 
     application.workspace_manager = FSWorkspaceManager(user_root_path)
 
@@ -153,7 +158,6 @@ def main(args=None) -> int:
                      'Starts a new {}'.format(SERVICE_TITLE),
                      __version__,
                      application_factory=create_application,
-                     log_file_prefix=WEBAPI_LOG_FILE_PREFIX,
                      args=args)
 
 

--- a/tests/ops/test_io.py
+++ b/tests/ops/test_io.py
@@ -269,7 +269,7 @@ class TestIO(TestCase):
                                  '2,3,51.2,11.8,-1,0.3\n')
 
 
-ENDPOINT_PORT = 3000
+ENDPOINT_PORT = 3020
 ENDPOINT_URL = f'http://127.0.0.1:{ENDPOINT_PORT}'
 
 MOTOSERVER_PATH = moto.server.__file__

--- a/tests/webapi/test_wsmanag.py
+++ b/tests/webapi/test_wsmanag.py
@@ -9,6 +9,7 @@ from cate.util.web.webapi import find_free_port, WebAPI
 from cate.webapi.wsmanag import WebAPIWorkspaceManager
 from tests.core.test_wsmanag import WorkspaceManagerTestMixin
 
+_SERVICE_LOG_FILE = 'pytest-log.txt'
 _SERVICE_INFO_FILE = 'pytest-service-info.json'
 
 
@@ -22,6 +23,7 @@ class WebAPIWorkspaceManagerTest(WorkspaceManagerTestMixin, unittest.TestCase):
         WebAPI.start_subprocess('cate.webapi.start',
                                 port=self.port,
                                 caller='pytest',
+                                log_file=_SERVICE_LOG_FILE,
                                 service_info_file=_SERVICE_INFO_FILE)
 
     def tearDown(self):


### PR DESCRIPTION
Improved logging for `cate-webapi-start` to allow for improved error analysis:

- Added new option `--logfile`.
- Changed meaning of option `--verbose`. Using this flag now sets log level to `DEBUG`. Warning: this setting affects all loggers, so expect vast output.
- Cate now outputs extra debugging information, if environment variable `CATE_DEBUG` is set to `1`. This affects WebSocket communication, image tile computations, and image tile caching. Output will always be streamed to stdout.

**EDIT**

Reviewers, please wait for review until the units tests run green.